### PR TITLE
pins Analytics 3.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Analytics (3.0.7)
+  - Analytics (3.2.4)
   - Expecta (1.0.5)
   - Optimizely-iOS-SDK (1.4.2)
   - Segment-Optimizely (1.1.0):
-    - Analytics (~> 3.0.3)
+    - Analytics (~> 3.0)
     - Optimizely-iOS-SDK (~> 1.4.2)
   - Specta (1.0.5)
 
@@ -17,10 +17,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
+  Analytics: d801f32615853ca3108216423dbaa829c74f5927
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Optimizely-iOS-SDK: 6d23c5cde187f894430d134caa15f56874754cca
-  Segment-Optimizely: e3e829b6a5fc6c8547e62111dc0d71800cd0b900
+  Segment-Optimizely: 563cf2378d41c1f9371926a62d764470cdb59263
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Analytics/Pod/Classes/Internal/NSData+GZIP.h
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/NSData+GZIP.h
@@ -1,0 +1,41 @@
+//
+//  GZIP.h
+//
+//  Version 1.1.1
+//
+//  Created by Nick Lockwood on 03/06/2012.
+//  Copyright (C) 2012 Charcoal Design
+//
+//  Distributed under the permissive zlib License
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/GZIP
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSData (GZIP)
+
+- (nullable NSData *)seg_gzippedData;
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/NSData+GZIP.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/NSData+GZIP.m
@@ -1,0 +1,107 @@
+//
+//  GZIP.m
+//
+//  Version 1.1.1
+//
+//  Created by Nick Lockwood on 03/06/2012.
+//  Copyright (C) 2012 Charcoal Design
+//
+//  Distributed under the permissive zlib License
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/GZIP
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+
+#import "NSData+GZIP.h"
+#import <zlib.h>
+#import <dlfcn.h>
+
+
+#pragma clang diagnostic ignored "-Wcast-qual"
+
+
+@implementation NSData (GZIP)
+
+static void *seg_libzOpen()
+{
+    static void *libz;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        libz = dlopen("/usr/lib/libz.dylib", RTLD_LAZY);
+    });
+    return libz;
+}
+
+- (NSData *)seg_gzippedDataWithCompressionLevel:(float)level
+{
+    if (self.length == 0 || [self seg_isGzippedData]) {
+        return self;
+    }
+
+    void *libz = seg_libzOpen();
+    int (*deflateInit2_)(z_streamp, int, int, int, int, int, const char *, int) =
+        (int (*)(z_streamp, int, int, int, int, int, const char *, int))dlsym(libz, "deflateInit2_");
+    int (*deflate)(z_streamp, int) = (int (*)(z_streamp, int))dlsym(libz, "deflate");
+    int (*deflateEnd)(z_streamp) = (int (*)(z_streamp))dlsym(libz, "deflateEnd");
+
+    z_stream stream;
+    stream.zalloc = Z_NULL;
+    stream.zfree = Z_NULL;
+    stream.opaque = Z_NULL;
+    stream.avail_in = (uint)self.length;
+    stream.next_in = (Bytef *)(void *)self.bytes;
+    stream.total_out = 0;
+    stream.avail_out = 0;
+
+    static const NSUInteger ChunkSize = 16384;
+
+    NSMutableData *output = nil;
+    int compression = (level < 0.0f) ? Z_DEFAULT_COMPRESSION : (int)(roundf(level * 9));
+    if (deflateInit2(&stream, compression, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY) == Z_OK) {
+        output = [NSMutableData dataWithLength:ChunkSize];
+        while (stream.avail_out == 0) {
+            if (stream.total_out >= output.length) {
+                output.length += ChunkSize;
+            }
+            stream.next_out = (uint8_t *)output.mutableBytes + stream.total_out;
+            stream.avail_out = (uInt)(output.length - stream.total_out);
+            deflate(&stream, Z_FINISH);
+        }
+        deflateEnd(&stream);
+        output.length = stream.total_out;
+    }
+
+    return output;
+}
+
+- (NSData *)seg_gzippedData
+{
+    return [self seg_gzippedDataWithCompressionLevel:-1.0f];
+}
+
+- (BOOL)seg_isGzippedData
+{
+    const UInt8 *bytes = (const UInt8 *)self.bytes;
+    return (self.length >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b);
+}
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsRequest.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsRequest.m
@@ -6,7 +6,8 @@
 #import "SEGAnalyticsRequest.h"
 
 
-@interface SEGAnalyticsRequest () <NSURLConnectionDataDelegate> {
+@interface SEGAnalyticsRequest () <NSURLConnectionDataDelegate>
+{
     NSMutableData *_responseData;
 }
 

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsUtils.m
@@ -32,7 +32,7 @@ NSString *iso8601FormattedString(NSDate *date)
     dispatch_once(&onceToken, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
         dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
+        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     });
     return [dateFormatter stringFromDate:date];
 }

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGBluetooth.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGBluetooth.m
@@ -44,5 +44,4 @@ const NSString *SEGCentralManagerClass = @"CBCentralManager";
 }
 
 - (void)centralManagerDidUpdateState:(id)central {}
-
 @end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
@@ -10,20 +10,24 @@
 #import "SEGAnalyticsUtils.h"
 #import <CoreLocation/CoreLocation.h>
 
-#define LOCATION_STRING_PROPERTY(NAME, PLACEMARK_PROPERTY)                                      \
-    -(NSString *)NAME                                                                           \
-    {                                                                                           \
-        __block NSString *result = nil;                                                         \
-        dispatch_sync(self.syncQueue, ^{ result = self.currentPlacemark.PLACEMARK_PROPERTY; }); \
-        return result;                                                                          \
+#define LOCATION_STRING_PROPERTY(NAME, PLACEMARK_PROPERTY)     \
+    -(NSString *)NAME                                          \
+    {                                                          \
+        __block NSString *result = nil;                        \
+        dispatch_sync(self.syncQueue, ^{                       \
+            result = self.currentPlacemark.PLACEMARK_PROPERTY; \
+        });                                                    \
+        return result;                                         \
     }
 
-#define LOCATION_NUMBER_PROPERTY(NAME, PLACEMARK_PROPERTY)                                         \
-    -(NSNumber *)NAME                                                                              \
-    {                                                                                              \
-        __block NSNumber *result = nil;                                                            \
-        dispatch_sync(self.syncQueue, ^{ result = @(self.currentPlacemark.PLACEMARK_PROPERTY); }); \
-        return result;                                                                             \
+#define LOCATION_NUMBER_PROPERTY(NAME, PLACEMARK_PROPERTY)        \
+    -(NSNumber *)NAME                                             \
+    {                                                             \
+        __block NSNumber *result = nil;                           \
+        dispatch_sync(self.syncQueue, ^{                          \
+            result = @(self.currentPlacemark.PLACEMARK_PROPERTY); \
+        });                                                       \
+        return result;                                            \
     }
 
 #define LOCATION_AGE 300.0 // 5 minutes

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGStoreKitTracker.h
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGStoreKitTracker.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+#import "SEGAnalytics.h"
+
+
+@interface SEGStoreKitTracker : NSObject <SKPaymentTransactionObserver, SKProductsRequestDelegate>
+
++ (instancetype)trackTransactionsForAnalytics:(SEGAnalytics *)analytics;
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGStoreKitTracker.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGStoreKitTracker.m
@@ -1,0 +1,91 @@
+#import "SEGStoreKitTracker.h"
+
+
+@interface SEGStoreKitTracker ()
+
+@property (nonatomic, readonly) SEGAnalytics *analytics;
+@property (nonatomic, readonly) NSMutableDictionary *transactions;
+@property (nonatomic, readonly) NSMutableDictionary *productRequests;
+
+@end
+
+
+@implementation SEGStoreKitTracker
+
++ (instancetype)trackTransactionsForAnalytics:(SEGAnalytics *)analytics
+{
+    return [[SEGStoreKitTracker alloc] initWithAnalytics:analytics];
+}
+
+- (instancetype)initWithAnalytics:(SEGAnalytics *)analytics
+{
+    if (self = [self init]) {
+        _analytics = analytics;
+        _productRequests = [NSMutableDictionary dictionaryWithCapacity:1];
+        _transactions = [NSMutableDictionary dictionaryWithCapacity:1];
+
+        [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+}
+
+#pragma mark - SKPaymentQueue Observer
+- (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions
+{
+    for (SKPaymentTransaction *transaction in transactions) {
+        if (transaction.transactionState != SKPaymentTransactionStatePurchased) {
+            continue;
+        }
+
+        SKProductsRequest *request = [[SKProductsRequest alloc] initWithProductIdentifiers:[NSSet setWithObject:transaction.payment.productIdentifier]];
+        @synchronized(self)
+        {
+            [self.transactions setObject:transaction forKey:transaction.payment.productIdentifier];
+            [self.productRequests setObject:request forKey:transaction.payment.productIdentifier];
+        }
+        request.delegate = self;
+        [request start];
+    }
+}
+
+#pragma mark - SKProductsRequest delegate
+- (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response
+{
+    for (SKProduct *product in response.products) {
+        @synchronized(self)
+        {
+            SKPaymentTransaction *transaction = [self.transactions objectForKey:product.productIdentifier];
+            [self trackTransaction:transaction forProduct:product];
+            [self.transactions removeObjectForKey:product.productIdentifier];
+            [self.productRequests removeObjectForKey:product.productIdentifier];
+        }
+    }
+}
+
+#pragma mark - Track
+- (void)trackTransaction:(SKPaymentTransaction *)transaction forProduct:(SKProduct *)product
+{
+    NSString *currency = [product.priceLocale objectForKey:NSLocaleCurrencyCode];
+
+    [self.analytics track:@"Order Completed" properties:@{
+        @"orderId" : transaction.transactionIdentifier,
+        @"affiliation" : @"App Store",
+        @"currency" : currency,
+        @"products" : @[
+            @{
+               @"productId" : product.productIdentifier,
+               @"quantity" : @(transaction.payment.quantity),
+               @"sku" : transaction.transactionIdentifier,
+               @"price" : product.price,
+               @"name" : product.localizedTitle
+            }
+        ]
+    }];
+}
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.h
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+
+@interface UIViewController (SEGScreen)
+
++ (void)seg_swizzleViewDidAppear;
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -1,0 +1,82 @@
+#import "UIViewController+SEGScreen.h"
+#import <objc/runtime.h>
+#import "SEGAnalytics.h"
+#import "SEGAnalyticsUtils.h"
+
+
+@implementation UIViewController (SEGScreen)
+
++ (void)seg_swizzleViewDidAppear
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+
+        SEL originalSelector = @selector(viewDidAppear:);
+        SEL swizzledSelector = @selector(seg_viewDidAppear:);
+
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+
+        BOOL didAddMethod =
+            class_addMethod(class,
+                            originalSelector,
+                            method_getImplementation(swizzledMethod),
+                            method_getTypeEncoding(swizzledMethod));
+
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+
++ (UIViewController *)seg_topViewController
+{
+    UIViewController *root = [UIApplication sharedApplication].delegate.window.rootViewController;
+    return [self seg_topViewController:root];
+}
+
++ (UIViewController *)seg_topViewController:(UIViewController *)rootViewController
+{
+    if (rootViewController.presentedViewController == nil) {
+        return rootViewController;
+    }
+
+    if ([rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *navigationController = (UINavigationController *)rootViewController.presentedViewController;
+        UIViewController *lastViewController = [[navigationController viewControllers] lastObject];
+        return [self seg_topViewController:lastViewController];
+    }
+
+    UIViewController *presentedViewController = (UIViewController *)rootViewController.presentedViewController;
+    return [self seg_topViewController:presentedViewController];
+}
+
+- (void)seg_viewDidAppear:(BOOL)animated
+{
+    UIViewController *top = [UIViewController seg_topViewController];
+    if (!top) {
+        return;
+    }
+
+    NSString *name = [top title];
+    if (!name) {
+        name = [[[top class] description] stringByReplacingOccurrencesOfString:@"ViewController" withString:@""];
+        // Class name could be just "ViewController".
+        if (name.length == 0) {
+            SEGLog(@"Could not infer screen name.");
+            name = @"Unknown";
+        }
+    }
+    [[SEGAnalytics sharedAnalytics] screen:name properties:nil options:nil];
+
+    [self seg_viewDidAppear:animated];
+}
+
+@end

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
@@ -1,6 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "SEGIntegrationFactory.h"
 
+/**
+ * NSNotification name, that is posted after integrations are loaded.
+ */
+extern NSString *SEGAnalyticsIntegrationDidStart;
+
 @protocol SEGIntegrationFactory;
 
 /**
@@ -37,6 +42,21 @@
  */
 @property (nonatomic, assign) NSUInteger flushAt;
 
+
+/**
+ * Whether the analytics client should automatically make a track call for application lifecycle events, such as "Application Installed", "Application Updated" and "Application Opened".
+ */
+@property (nonatomic, assign) BOOL trackApplicationLifecycleEvents;
+
+/**
+ * Whether the analytics client should automatically make a screen call when a view controller is added to a view hierarchy. Because the underlying implementation uses method swizzling, we recommend initializing the analytics client as early as possible (before any screens are displayed), ideally during the Application delegate's applicationDidFinishLaunching method.
+ */
+@property (nonatomic, assign) BOOL recordScreenViews;
+
+/**
+ * Whether the analytics client should automatically track in-app purchases from the App Store.
+ */
+@property (nonatomic, assign) BOOL trackInAppPurchases;
 
 /**
  * Register a factory that can be used to create an integration.

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
@@ -5,11 +5,12 @@
 #import "SEGAnalyticsUtils.h"
 #import "SEGAnalyticsRequest.h"
 #import "SEGAnalytics.h"
-
 #import "SEGIntegrationFactory.h"
 #import "SEGIntegration.h"
-#import <objc/runtime.h>
 #import "SEGSegmentIntegrationFactory.h"
+#import "UIViewController+SEGScreen.h"
+#import "SEGStoreKitTracker.h"
+#import <objc/runtime.h>
 
 static SEGAnalytics *__sharedInstance = nil;
 NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.did.start";
@@ -75,6 +76,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 @property (nonatomic, strong) NSMutableDictionary *integrations;
 @property (nonatomic, strong) NSMutableDictionary *registeredIntegrations;
 @property (nonatomic) volatile BOOL initialized;
+@property (nonatomic, strong) SEGStoreKitTracker *storeKitTracker;
 
 @end
 
@@ -123,12 +125,64 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
                                   UIApplicationDidBecomeActiveNotification ]) {
             [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
         }
+
+        if (configuration.recordScreenViews) {
+            [UIViewController seg_swizzleViewDidAppear];
+        }
+        if (configuration.trackInAppPurchases) {
+            _storeKitTracker = [SEGStoreKitTracker trackTransactionsForAnalytics:self];
+        }
+        [self trackApplicationLifecycleEvents:configuration.trackApplicationLifecycleEvents];
     }
     return self;
 }
 
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
 #pragma mark - NSNotificationCenter Callback
+NSString *const SEGVersionKey = @"SEGVersionKey";
+NSString *const SEGBuildKey = @"SEGBuildKey";
+
+- (void)trackApplicationLifecycleEvents:(BOOL)trackApplicationLifecycleEvents
+{
+    if (!trackApplicationLifecycleEvents) {
+        return;
+    }
+
+    NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
+    NSInteger previousBuild = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKey];
+
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    NSInteger currentBuild = [[[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"] integerValue];
+
+    if (!previousBuild) {
+        [self track:@"Application Installed" properties:@{
+            @"version" : currentVersion,
+            @"build" : @(currentBuild)
+        }];
+    } else if (currentBuild != previousBuild) {
+        [self track:@"Application Updated" properties:@{
+            @"previous_version" : previousVersion,
+            @"previous_build" : @(previousBuild),
+            @"version" : currentVersion,
+            @"build" : @(currentBuild)
+        }];
+    }
+
+
+    [self track:@"Application Opened" properties:@{
+        @"version" : currentVersion,
+        @"build" : @(currentBuild)
+    }];
+
+    [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
+    [[NSUserDefaults standardUserDefaults] setInteger:currentBuild forKey:SEGBuildKey];
+}
 
 
 - (void)onAppForeground:(NSNotification *)note
@@ -143,19 +197,19 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     static dispatch_once_t selectorMappingOnce;
     dispatch_once(&selectorMappingOnce, ^{
         selectorMapping = @{
-                            UIApplicationDidFinishLaunchingNotification :
-                                NSStringFromSelector(@selector(applicationDidFinishLaunching:)),
-                            UIApplicationDidEnterBackgroundNotification :
-                                NSStringFromSelector(@selector(applicationDidEnterBackground)),
-                            UIApplicationWillEnterForegroundNotification :
-                                NSStringFromSelector(@selector(applicationWillEnterForeground)),
-                            UIApplicationWillTerminateNotification :
-                                NSStringFromSelector(@selector(applicationWillTerminate)),
-                            UIApplicationWillResignActiveNotification :
-                                NSStringFromSelector(@selector(applicationWillResignActive)),
-                            UIApplicationDidBecomeActiveNotification :
-                                NSStringFromSelector(@selector(applicationDidBecomeActive))
-                            };
+            UIApplicationDidFinishLaunchingNotification :
+                NSStringFromSelector(@selector(applicationDidFinishLaunching:)),
+            UIApplicationDidEnterBackgroundNotification :
+                NSStringFromSelector(@selector(applicationDidEnterBackground)),
+            UIApplicationWillEnterForegroundNotification :
+                NSStringFromSelector(@selector(applicationWillEnterForeground)),
+            UIApplicationWillTerminateNotification :
+                NSStringFromSelector(@selector(applicationWillTerminate)),
+            UIApplicationWillResignActiveNotification :
+                NSStringFromSelector(@selector(applicationWillResignActive)),
+            UIApplicationDidBecomeActiveNotification :
+                NSStringFromSelector(@selector(applicationDidBecomeActive))
+        };
     });
     SEL selector = NSSelectorFromString(selectorMapping[note.name]);
     if (selector) {
@@ -428,7 +482,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
 + (NSString *)version
 {
-    return @"3.0.7";
+    return @"3.2.4";
 }
 
 #pragma mark - Private

--- a/Example/Pods/Analytics/README.md
+++ b/Example/Pods/Analytics/README.md
@@ -1,6 +1,5 @@
 # Analytics
 
-[![CI Status](https://img.shields.io/travis/segmentio/analytics-ios.svg?style=flat)](https://travis-ci.org/segmentio/analytics-ios)
 [![Version](https://img.shields.io/cocoapods/v/Analytics.svg?style=flat)](https://cocoapods.org//pods/Analytics)
 [![License](https://img.shields.io/cocoapods/l/Analytics.svg?style=flat)](http://cocoapods.org/pods/Analytics)
 
@@ -40,7 +39,7 @@ WWWWWW||WWWWWW
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Segment, Inc.
+Copyright (c) 2016 Segment, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Example/Pods/Headers/Private/Analytics/NSData+GZIP.h
+++ b/Example/Pods/Headers/Private/Analytics/NSData+GZIP.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/NSData+GZIP.h

--- a/Example/Pods/Headers/Private/Analytics/SEGStoreKitTracker.h
+++ b/Example/Pods/Headers/Private/Analytics/SEGStoreKitTracker.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/SEGStoreKitTracker.h

--- a/Example/Pods/Headers/Private/Analytics/UIViewController+SEGScreen.h
+++ b/Example/Pods/Headers/Private/Analytics/UIViewController+SEGScreen.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.h

--- a/Example/Pods/Headers/Public/Analytics/NSData+GZIP.h
+++ b/Example/Pods/Headers/Public/Analytics/NSData+GZIP.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/NSData+GZIP.h

--- a/Example/Pods/Headers/Public/Analytics/SEGStoreKitTracker.h
+++ b/Example/Pods/Headers/Public/Analytics/SEGStoreKitTracker.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/SEGStoreKitTracker.h

--- a/Example/Pods/Headers/Public/Analytics/UIViewController+SEGScreen.h
+++ b/Example/Pods/Headers/Public/Analytics/UIViewController+SEGScreen.h
@@ -1,0 +1,1 @@
+../../../Analytics/Pod/Classes/Internal/UIViewController+SEGScreen.h

--- a/Example/Pods/Local Podspecs/Segment-Optimizely.podspec.json
+++ b/Example/Pods/Local Podspecs/Segment-Optimizely.podspec.json
@@ -22,7 +22,7 @@
   "source_files": "Pod/Classes/**/*",
   "dependencies": {
     "Analytics": [
-      "~> 3.0.3"
+      "~> 3.0"
     ],
     "Optimizely-iOS-SDK": [
       "~> 1.4.2"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Analytics (3.0.7)
+  - Analytics (3.2.4)
   - Expecta (1.0.5)
   - Optimizely-iOS-SDK (1.4.2)
   - Segment-Optimizely (1.1.0):
-    - Analytics (~> 3.0.3)
+    - Analytics (~> 3.0)
     - Optimizely-iOS-SDK (~> 1.4.2)
   - Specta (1.0.5)
 
@@ -17,10 +17,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
+  Analytics: d801f32615853ca3108216423dbaa829c74f5927
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Optimizely-iOS-SDK: 6d23c5cde187f894430d134caa15f56874754cca
-  Segment-Optimizely: e3e829b6a5fc6c8547e62111dc0d71800cd0b900
+  Segment-Optimizely: 563cf2378d41c1f9371926a62d764470cdb59263
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,152 +7,158 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A9AEC7CF42E01E5F5CEE630C540911 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = 4167BC316233780293ADA7C9B9F11666 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02F57F05FAE6B4D55E1F3933C209D4EA /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A97FB897B0C7694594BBFEE66DDB7D /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02FA0FA148C2B4F13646BCD671C1DC0D /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D258AB5A8C5301A7FB35AA14F67EC0E /* SEGTrackPayload.m */; };
-		07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B7128E4B9B0A9229E6554A01BA058B /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = D506AE952E73CD635A6319D2EED3CFE7 /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00261FFBC13BECCACD6B764AE2A193E7 /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = D93BBD027019BDEDC44007A499836B93 /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = C7DDD3A45660A21C6831853333BFF867 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = B29EFBE11118B62D214188BEEACD2676 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02F57F05FAE6B4D55E1F3933C209D4EA /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = D51C1BB513557F875185B60745A59C17 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05CEE7001DE28EFC6E052322F6E60818 /* UIViewController+SEGScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 61EEBE06EA0B804141D251CB3B5612AF /* UIViewController+SEGScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = F50A5D49A088521E9A5C29AF590C5E17 /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C5186074C38F7A8415A10A37B5EEC12C /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0959BF3A9EA8DDCD91BDD6C204C99746 /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DA7F17ABB37B55AD0000CE7989208BE /* SEGTrackPayload.m */; };
 		0B65EA8A6FB55C21A7F5164679935337 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		0EBFCC5B0D8267DB953A68498EC7D758 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 620B1A6AA12811DA01076E70A13F76D7 /* SEGAliasPayload.m */; };
-		104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = AF091B958E38840A17231F281F66837E /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		10640AF349457B2280632CECCCA5FE7C /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = B098A6857E45554F131A3F8189A5F346 /* SEGScreenPayload.m */; };
-		11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = B425BB1AC00B45F5B31218B84812DB4F /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = E6E6FB0CD93C9470FABF060BD77D50FD /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		16D6B200143BA192930C006AE395DC71 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 0715583339195703602EEE41BF3519B2 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		174B3E8378830E0C54594E5FE309F027 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = F4A2B55ADCFF0929DAF7E5701FDB624F /* SPTSharedExampleGroups.m */; };
-		19C02B6A96CDCC8631DE62BE33EC247D /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C36BF0E6A66460876DAAF293E6961DF /* SPTTestSuite.m */; };
-		20386D888D0E90121C458B86C22C92D1 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 441208E2B7F088B88181EA8ABA1FB246 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = E302CF469D20505FC249F6CB5D869B49 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E2D701BB322BD08CE6134666C831254 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		239E33DFA7D2D46715B87AF6FA704A38 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = C3EAEA19415FF7EBAA073A6075D81E53 /* SPTExampleGroup.m */; };
-		25BBDA674BE9447D354412C79BF4B16C /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = A12B53A62FFFD93760A25EEDE51D952D /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26FDD94D57A937677D2A42E53E7DBD7A /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = FD34E27A04D88FE7D3CBD9D0EDCF0688 /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = FA28582DEA6A8933E1AA38F90AFB10EC /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D9CDB6D4CD9DDC5069353E6CDA13577 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 565C035DA2537D35FC716FE8725B87E4 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		16D6B200143BA192930C006AE395DC71 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = EB2F23591EDA36F6FD225E562AFA540C /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		174B3E8378830E0C54594E5FE309F027 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = C12566A4A8D3AE966344AE005E840D61 /* SPTSharedExampleGroups.m */; };
+		18BBCADDC3F815317F973D413D2CD648 /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FFA70669483D6D4EE2251EC04D6E3A /* SEGAnalyticsUtils.m */; };
+		19C02B6A96CDCC8631DE62BE33EC247D /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FE7825789011559A6BE402762A83F28 /* SPTTestSuite.m */; };
+		20386D888D0E90121C458B86C22C92D1 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A20186DC203A1F8F6E2D65810EF6C6B /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		21F35874229FAC9619E1B4AEA0E4E259 /* SEGStoreKitTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = D77AEA1601836427C63E2B6187F0C0B1 /* SEGStoreKitTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = BB9C90E08D26F49AF29F3291130B4C5C /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		22E2AD61FEB3923D64F8283D90A4F5D0 /* SEGStoreKitTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B977A98AC7F5EB5CC66EFED48C2BABC8 /* SEGStoreKitTracker.m */; };
+		237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DB307FC4137BC83C0631235ABA838D5 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		239E33DFA7D2D46715B87AF6FA704A38 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3B86DAD63479DB5CE300673D3808AF /* SPTExampleGroup.m */; };
 		28880CE27E58C9F9781B2448C4D3C874 /* SEGOptimizelyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 25FA9CE2C75E380E2A0AF87FBAF1BE97 /* SEGOptimizelyIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28D20AA9896D24878E230D1889A10D8C /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB4187CB67DFCE289D005A02DFB1373 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 502E84BBA4C7B3E20D64064C4921CE23 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 318B214C0CBB5B67A437109326A752DD /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28D20AA9896D24878E230D1889A10D8C /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 032983F37E7F2FF914CD0A01488C38BD /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 62763862C2C2918191D0F725A6E8B970 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = E0B9B3E86F6895CE056089349373F21E /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D481CAF8A5A8878973D186B6504BB8D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		2F824EA28F819F2E4A9E6D31E14D0603 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CE8D0340B0E23EDD17E4DB34B1BDD38 /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EAC803DBF4166B6FB158C5746285EE1 /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = AA98737427C7A1032C4A3A6E93FBD36E /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		328FFCBDCEF0C4B0E50DA8C97A4C262F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */; };
-		339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 402A0FFC7DAA5190492E06B8CB353D9A /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 50ED845FB73736D1928A270774F4354F /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = A8F63A304CB8536906114FF0E4CDAA9E /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CF85CEBEA5339235C29E19B55D944ED /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C01D595EFBB7C616E1E7E9AD83C066 /* SEGSegmentIntegration.m */; };
-		3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 186B2A080B645D7968B79FE4A165F32F /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = D719E052C40A18C5C3F419E3B32A88E6 /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		41D47B37FDEA46945606C39C44042D8C /* SEGLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B42FB13E27538E40FBB1F320F9D46F8 /* SEGLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 56E24ADAD8C42B94103BA6A3F005EE87 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BCCDDB8AEB518A5B4BC3486797950BB /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 0298B3E429D05DB07F44F3910DA9A8CC /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = ECD92DCF672B315A64EF4E3F6CCA2EDA /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 400879EB9A3AAA9CA4DDEAB583B34D62 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = ADADDEE6CF644657B41F2DF33AB3DE1D /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		345DF8E2A74A614DBAEDED37B9F97D32 /* SEGBluetooth.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB25922404D5DD857878AEAFEB1136D /* SEGBluetooth.m */; };
+		3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = C9BA566801C95162E60801E023A6BFC8 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B7A251527E2D0A8B75B00B3C389EEEA /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = BC78ADC14991B0EF4A7F977A710E553A /* SEGAnalytics.m */; };
+		3BF5D4402A44F82F26C3B59C6F8D4421 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = CC5AABBA1754A29CC27823EF17C27933 /* SEGIdentifyPayload.m */; };
+		3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 82452606A3149F30F3AA2C495803E764 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EBFA024D42A3181FB7BFF0876370EC0 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 44D5232BFE81021EDB083BE574F6CC7F /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = ABC5ED6050F1089A9EF61141C6197EC2 /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FD2A195CF6D347A7BCFDAD35DF2B5AA /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 26F04E7558CC35C72FF99704FFDB93DA /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = B4F519AF0DDC8A146241887439986236 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD6A97E99ADB95781EAE1D86470EE4C /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		462E620D68B093568E74CF433ECECEE7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C86882503A869B211AA224C57E6F79A /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		486B65BB914388EA36C58304C6039F1F /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D9DE4EF913C62588F8D678B4F84AA9 /* Analytics-dummy.m */; };
-		486DB016ABF54C86824237556E9E4984 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7CABF7FBB4D56ABB53122992DB5F49 /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D7892C7CEE19A26BBD37B194F8D53 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		496063D30B1C193D1B25492DC7AB72B8 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = 91E54AAF582A9DD46AEB656F556474C7 /* XCTestCase+Specta.m */; };
-		49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 87CE9D3DA8656A383F94B5F97A3512A2 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		46390BE9EE31B6BF29D89D467F9936D1 /* SEGLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = F308F157CEE56FAFE74887B3616CE5B4 /* SEGLocation.m */; };
+		46DD92E53969E586C5AF66929893E005 /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = E4FFA598FE8E75AC0B16CA04096E966E /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 532604FAA611174FB30F9A153B96EDD9 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		486DB016ABF54C86824237556E9E4984 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = ED51660FBE8D8ED03F7D52E47DD6D187 /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E82F36A9DA5892FEF5387BC07F9894C /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		496063D30B1C193D1B25492DC7AB72B8 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = D055171EC1A1F3B92BE4A1CC6A82C709 /* XCTestCase+Specta.m */; };
+		49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 81641943666D862D21CAE95DCFD6C028 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4B008984AEDE4680E20819C62BBD57FA /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 35515136B5A0D7C8EC9258EAA738CECC /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CE7CB117822A3267FD51C0A4DDEFF22 /* SEGOptimizelyIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B1B01DBEE6960A1F55641A3AC931D0E /* SEGOptimizelyIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4E75CAE7E2F3036BE31A3D2071EE3CB5 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 9963EAF1DDCA0173B5432203C55FDD0D /* SpectaDSL.m */; };
-		521A03AF5C304D9639C7C5AFBC3D676E /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 244E2CB9325EB8C4349D0C28A33C44BF /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5236D7F459C65CEBAE1CD0F5A01F257D /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 83658D3D5E52D40F772336A71661F23F /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		539C2C0907CA46CC4DE78E19B1AFFA8E /* SEGBluetooth.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D4D5718493EE0C3FFBA3DD21C8F042A /* SEGBluetooth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F5B8AFCE2C53DAAA1D4AD66CCDA7C73 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5D58B5F7F274DCB0CB21B85BF4EACEA6 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = F183F307D83E956C2EB9630A680CD8D9 /* SPTCallSite.m */; };
-		5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 242D48173DA1A1E589003C59702FE4B1 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B77E4920E457AB52A342378FAE85807 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E9E4F16FB96F6B1B03743ED69515CD5 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = B53975F33C34AF5E75DD03091C4F85D0 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		65EE6DE887B1D5E52B5E017EDC173915 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BF58EF0DD0E14CEF960083DB4F80C85 /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E75CAE7E2F3036BE31A3D2071EE3CB5 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = D6A449F5F1C2BDE1BBA8A9D71FB20278 /* SpectaDSL.m */; };
+		521A03AF5C304D9639C7C5AFBC3D676E /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 31BAEBDD3D1CD01AB1D8704BE1E02D1B /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5236D7F459C65CEBAE1CD0F5A01F257D /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E1544023659E84F0EF8D7917FDBE642 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		532CD209E5D9A1699BC51D1FCBFAF79D /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 94FA446F21A14C5C6080B7E93BE21EFE /* SEGPayload.m */; };
+		562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = CF95B1A533B3179908368CF62F3FD6BD /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		56AE1A75484F81A02706C56E80C836E0 /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C044919FC2E97294363C21C4E082A80 /* SEGScreenPayload.m */; };
+		5849D7DCDF2B79E22AD4F96D083B08F1 /* NSData+GZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 595D70BE490362F369AB64CB883F636A /* NSData+GZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D58B5F7F274DCB0CB21B85BF4EACEA6 /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EBE032F3D929DE77852A84A0D0F24D8 /* SPTCallSite.m */; };
+		5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = EBBBD24A2BBBC7E14F5DB703B0C90DC4 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = B423E47101EDB0CC51F97A299598F979 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = C2A3B6C10152855C5D933DE13374CD19 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 36D3F8B5CD7112D5E0C7EC78D6CB0902 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		65EE6DE887B1D5E52B5E017EDC173915 /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CA89F8E2298273E0A5A0560582E1609 /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66081D3480D1FA028C4DE2344BF616D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		66ED669D42B1035789CE51D6A5C86EB0 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 4054B6414B0EC415B58289E6AD5C5DC0 /* SEGGroupPayload.m */; };
-		68E10C74572004B18490C31A0757E3B2 /* SEGBluetooth.m in Sources */ = {isa = PBXBuildFile; fileRef = A5ADAEC813D5A7106930076A5B3D34F8 /* SEGBluetooth.m */; };
-		6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 70FC5B39250B573536927ACD46A76CE2 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FE238F964B516A544B9BCB3F9D96846 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69363A59A4E2FF95D6A62AA88641A20A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */; };
-		69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = A4D79824A5642E7F944713C91FA200D6 /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 05CAB1FD23AE421837CDB508F004399F /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6CBB0742821FD4D346404011AE148582 /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = EE8DFB16A45932AA6BE0978D8C0995FB /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 17D769918D41BA08AFF8B66157EAA16B /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E53A8EA6AEAB2F9184270EF46FF9EFD /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7051A9955D024A9CDC76491A90BF8824 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B4218C263EC6361910EE95D400C6FB0 /* SPTExample.m */; };
-		70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = A14449D0C3CEBADE0FB520BA1C781A47 /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		736FFE8C1DA66D78EFDBB6C44B58F49B /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = A05F25AA3EA485A7ABB943BF501B0209 /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E2FA2231028693909EDEFB4BDC98D96C /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8D9CF7D379CE13739E69B2554A89C3 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 63D495760CD72CAF10D25CC7D73700AD /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FD3BB129658F5F92B1A8A7A003B479 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C1923A70C2957662E471C4182FC68EE /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F99F346CEC7597BC4AD63F1E966D594 /* SEGAnalyticsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A8458CDA442816187EFCD6F17472F0C /* SEGAnalyticsRequest.m */; };
-		7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = F1FDD77A1259479B0BF17F8D9067920D /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A6AE62D69E931267C8266356CFB1D2 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 0324C64448608A6E80918A520EE34FB7 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8B1B60B7C24DCFAC0081FE5432C10942 /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BC63C242F3D3766D652493C227ED9922 /* SEGSegmentIntegrationFactory.m */; };
-		8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DBEDBE65A5261543E2D4E7B0CBEBC78 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F4C12E9D220B309ED193E42EDBDE4FF /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F8B382D1231AE6FCA478E3C79F036AD /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C54014F3B847A5EDCD84E8888097C26 /* SEGAnalytics.m */; };
-		9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D15A4A7D98D7A6C838D285D843ABC8C0 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		901C95FA513F8BEC6992EE457A527DE1 /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 253272B3AA6F7D7B8C42E00C11BAE9AB /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		91716783ABA4BA9B79B0501A0CDB59D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 93647A2472225B8562A58EB076032DAC /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = EC66943145F2DC7358ABFA49F8E44D1B /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		98A22457F5E28CAF0B7E113A6D4142A1 /* SEGAnalyticsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = C8E3A8E99AFB130AAA2651890FEB7078 /* SEGAnalyticsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 795BF5CFADA760A6831262C85D951B44 /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = BA235E5A23582C29F9FB804C5C021AC7 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 78CBE6ED70FDB2D1968E22F43A227C29 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A06621B38722ADB1576FCFAE582AC4E /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7051A9955D024A9CDC76491A90BF8824 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FA546A23E031D797CE9640AD73C967E /* SPTExample.m */; };
+		70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = C559C72057088CC3CA122461879728CC /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		710616E865E2AE52C4CFA7EBBAC84FA9 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A096B69CEC7C8F4BEB4F4B4A01058B2 /* SEGAliasPayload.m */; };
+		736FFE8C1DA66D78EFDBB6C44B58F49B /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 987A67DCE85070A1D995348EDF5694D2 /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = C1591A96BDF0D138D44EA9B76C2E2E6C /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AC4F3BABDE0E7682E31B3494802E8FC /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AA40010024D315DE96322C88735DA42 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 971CDA5D9B01EE1E68612920627D4282 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 01AD61A3C8301A81F2C3C95A236CBBB9 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BB20DD2E90880DEA97B07536FDE482D /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D3CBF4F0B8FBB97E9FA2512096C14 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E56A0BB3DBB72671538BF14E0DE34A6 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		88A92561909149ACDC271FFCFCC730DA /* SEGBluetooth.h in Headers */ = {isa = PBXBuildFile; fileRef = BEE4F478C3279D1DC5090C09969C1DC0 /* SEGBluetooth.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AAADEF33FFB6F98FE49308C76DF3D68 /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 55D3CB13F1A774B7534A9E080CC90624 /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 9258F54EA01E90F23553C1F877297567 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D569C5B6637A228A4D65B956D557696 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8FA4F228A479384C25FFED7BB936CF0A /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 34AF9EBAAFE994B82265D530952FAE27 /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = C5BC365290F150267A1C761A9967557E /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = CF7AD8466A23599845CD730623E45DEB /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 844EBBF2DB6ADFD22ADBCDBEFCE370B4 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		994BB76453C59EEC88A7130423CB3912 /* Pods-Segment-Optimizely_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DF38826D48BE1D2FD3DDD0EE47CF00CD /* Pods-Segment-Optimizely_Example-dummy.m */; };
-		9AADAFF01BEEC14E343D024D6C229D5B /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 99139718A6BACA3B1356E1508C8F39DD /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B0205CF6F4A374BD7D4020067AF6E0C /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = C396B706031837181FDCE5CC7602084F /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B37FD66548104858FE30171C6D67B7E7 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = CF122A4D91B6733F615B196A9A460547 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A2A91F93C68DAE8C18FE53F6EA15D54D /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF48FDAD61E7EFFF3CF51642D34204A /* SEGReachability.m */; };
-		A3DD62F34A542D9B0C0EAEBB4C690CF3 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 9977C5E263BEE03EA90BFFBB74061736 /* SPTSpec.m */; };
-		A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 94697A97C0499B76466BDAB7DB0EB169 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D681198BE23C1B86D83F05649B07618 /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = D5BFB1224014C2F4FE31241DB5467629 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 440267A4DF204E5F57ECC67A81968CC3 /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9AADAFF01BEEC14E343D024D6C229D5B /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB62FC69799E38145E9FE1390F20488 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B0205CF6F4A374BD7D4020067AF6E0C /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F66962602F78434C77769D7D828A2AE /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 76F3820E305C6E4A49A28057C699882F /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1A90BFD7673DC790DF7B9BCFD1CBE44 /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FC0060866E4A94F5D3C97398FF8231B /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 4528D688226D5D93739A838C298CCF36 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A39FDF4EB81E6E583D65DBB1E73EDE96 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 11D85C17DE471463C5781E990F8F3735 /* NSData+GZIP.m */; };
+		A3DD62F34A542D9B0C0EAEBB4C690CF3 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = B30113ACD2F4485609E9D13342ACF4AF /* SPTSpec.m */; };
+		A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EB6FB4ACCECCED37C8A8BAF870DD28A /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = EFFDEB523A20D120BFAF893D1AD7DBAF /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = E3530244B27F2AD2EFD9D837D31040F5 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = BF0548068FF806210542294936BD08BD /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A95CA22842AC8E33798682B6B180CB86 /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 77851003AA523D040ED81A63E97ED37E /* Analytics-dummy.m */; };
 		A9F16F5684CE0D6DF92D71A21EFAD029 /* Pods-Segment-Optimizely_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB91C4F851A3B14CDE98FDF4ACC0A1B5 /* Pods-Segment-Optimizely_Tests-dummy.m */; };
-		AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A9938DF735F61654C8EBAD10DA5D049 /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AAB6E17E7976EFC449F580AE7B12CCF7 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 92B3E790E9A25308F0D5B0DFC9F1172D /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 9562ADC6B344F02FA1BFA08B4754D9E4 /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 68707517F93C563AFED4D595B6BCE02F /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AC73FE69DE5E3F72E6A92F7D39DFB22F /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 6347BD8B873CADAC8BC66C7F643791CA /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = F58A5303B2824AA348AA20DC40C7FA92 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B09EF0FD07655A036EF25A09252EC9A9 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = A01D565F912475D47892285ECA6BA3F8 /* SEGIdentifyPayload.m */; };
-		B309BC0D714443A4A815F45FECB8AAB1 /* SEGLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 286AB0802E5856E7E34531E9F52E4DD5 /* SEGLocation.m */; };
-		B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = EF76C0D7A2FEBC32B282C59D913D314D /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B5F7A213B1C490590EFAB25DF6AFD48A /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = E54EFA6DF743A51785BFCB7FCC81A779 /* SEGAnalyticsUtils.m */; };
-		B640D2616C6B00F0BAFE6EBD09A5D420 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B4A4B3F4EE8FBB28614B195EC7718F /* Specta-dummy.m */; };
-		B87904014217EC9142A60100E6D363E3 /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119DC1BECA6A3F59B13126626B6930C /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BEA0C19AB0231D1BAAB8FD16BDF8F8 /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAB6E17E7976EFC449F580AE7B12CCF7 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = D52FF053FF579F9A76BBA1CF2F25CA78 /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = 916958303CF130BF4E15B1E1C44C7EA8 /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 11052C241393984D10D2BCB14682837A /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC73FE69DE5E3F72E6A92F7D39DFB22F /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 07C5CACA8660B7AC7E5393FA10891BD5 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9103A2A09C41DEECDC77CBCC7D5DAB74 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 737DF3454379CA83979D3ABF63224EA8 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B640D2616C6B00F0BAFE6EBD09A5D420 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4188F15689EF6743D46B3C39480DF647 /* Specta-dummy.m */; };
 		BAAA3CE09C6B2E13D551BD3DCEC2C233 /* Segment-Optimizely-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9DB8746CC4B095438E4FDD90AA94BD /* Segment-Optimizely-dummy.m */; };
-		BC021CC978BE68B2BE0A690878FB54AF /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDBE2061B55E3F57516FCF2978A1625 /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AAA1400BF240ED1C3A2FF3E005D8045 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = CC41603E6052A6442A0F89EE02BF3414 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 593442D4C666A84B698D1A86D77735F3 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = B80D1FA0AF34E3A929C73C7FB66C4651 /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DE08B731D289E455A18859F3A70F332 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BC5E5FB01C96BFA0A4DC7758DA9FCE32 /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = D4D48CEC8BC0752AF325095F720B26CF /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = C445EE5C0E6FB9984B8CCFB57410636C /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = CE475E743136595C8D21F3487A40D17D /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A63A70CD2582BAD55AE0869C8C23909 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 563DD0EE1D87F5F47608D819774D3995 /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9B7C6A21989F6B0592618962A785749 /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = EC663AB176811EE2026D7587CEB7D0F4 /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 08EDFC104DBD6513B2563D134D38A2D4 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		CC1D557F6E1F818D29EDC757DC6EDFD4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F61FE2C30D626C53561D4EEE06A1A8 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B5CBC0A3B4715C9848F175A8DEEDE3B2 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D73A12A5D56A833DDE6DAEF8F02B93F0 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = E9BD83A8E331A110DB07B995BB274C6C /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAC08D09C7E4411C8B01CD2FCFCD247B /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 67B01F527AC4A15926697108C97F7FCA /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CF8127147AC2429245DBCE326522F7C5 /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E48571EB0D8A325E647FABCF28A5CE /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A8870AE5160CB46C2AA28ACF4CB36433 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 294ED2F20B00104692F1F4D173B524C4 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D595F164BCCDCAEAA4BED14480EBE0F2 /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 9044E29D277B5CC5BDAC489095F96678 /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D65C50CF7D039E7FE056192D3B335C31 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = FC2FB7CF4A559F56ABC165E43C702792 /* SEGGroupPayload.m */; };
+		D73A12A5D56A833DDE6DAEF8F02B93F0 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = DC4B940548D948970093463F4D0347F1 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DAC14309ED34D3C40EF7EB12FF1C657B /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = D90CFA8DBC6ABCF4CA293FBE2392A7E8 /* SEGSegmentIntegrationFactory.m */; };
+		DAE57F72A04F702C985AE999C3B01CBC /* UIViewController+SEGScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB93C25529BF8C411C89D9E56154151 /* UIViewController+SEGScreen.m */; };
 		DC336D1C60D43B2D319859B07EBE0D15 /* SEGOptimizelyIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BBA18D1850EC615E687310F7F57137A /* SEGOptimizelyIntegrationFactory.m */; };
-		DD7BED725086CF410512F736DE7AA95B /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F7A1136AE9866B1E6C4854D579E2AC0 /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = C2776B5E321F98D31184D19A97A32BAC /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 644872D6A1C873F1A64248B1C6EC74CB /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B06BA21A39C5C63CF87D068C4D60670 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E617E37B8DE4B930EC91E78E7B804A9C /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9265BD66D7D71D58B2CA48606B24310E /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0381736001DA348D8834BFC871D65897 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EAF89B49E64BC27FAC72688BDF7631E4 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = C6D2683E1A499E13F10AD2289429888C /* SPTCompiledExample.m */; };
-		EB27473B3153D1A32E331F8C3BC98E15 /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = F653B6B1695C00A5947990D9A13B947C /* SEGPayload.m */; };
-		EB92E02F32A97EF70D4F5C0C1A9A242A /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = FCF474C35D10B2698E2EC6F6340557AA /* SpectaUtility.m */; };
-		EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = AB3FE211889402FE94F4943B35EFDB2B /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF305FCB32346C76431C1202E7AD467B /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D6D34A0AAADCC655590C1D25E730F5 /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EAD58FA253AF023C763E0F1F7C346E0 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F280BEB32C116B6249D42E50A697B04B /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = B5934042AA0D1B0FE48D86CC370218B4 /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F9307335A85E8A0019099C1AB37F09C /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DE9A17A41AA556F8C10513C19FA69035 /* SEGLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = C14B3650BA8686C4F8D0C42CCFE65431 /* SEGLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = D21F2E43C83A03CC604E1F6D1BA4EFC8 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = BE35A5497B6BCDDFDA32DD702D862504 /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DBBB0A7CF97C484C98D6ABF97F8D27E /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E3D5F81DAF9C61EBC3247111A7FDC8A4 /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9B9478DE1C4CFC3115D3C296526294 /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = D24C7DE311FEC893DAEEB8737A2E58C0 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EAF89B49E64BC27FAC72688BDF7631E4 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = FA46AB517F65FC1FB879EE58BBAAFD2F /* SPTCompiledExample.m */; };
+		EB92E02F32A97EF70D4F5C0C1A9A242A /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CDC8257F6AFD5627FE675001B9B8F79 /* SpectaUtility.m */; };
+		EBAE9350B7A6F0A16D89E32EE4EB90CE /* SEGAnalyticsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E1FF37285A5A78CFB5711AA7766D95 /* SEGAnalyticsRequest.m */; };
+		EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3684A6D8F361D9CE174AB82C4F965A0D /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EEA91B5351A83B3D7937B28636A144D3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
+		F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 89367FC7978F8000C8319FD6F14AE600 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = C225EED69B5319A8B4464528E9EC9BAB /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F59DD31DAB3A1838402C4E16012E9433 /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F85BEA20FF32D708FD9B03009E01CC4 /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F5E618ADE827D22DB0D396AB3A3CD1CE /* SEGOptimizelyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F63FC89ED3994996C522F55523B73D3 /* SEGOptimizelyIntegration.m */; };
-		F6A5E9881D67168D9B9BFA5FCD834596 /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = B34FB02E50CB936D89830CB027F9EE1E /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F7E3BD700A9B2EA54BA4889E6B30DDDE /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = E2F3D0ECC82C69286BDB5C4F1371855A /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DE62E13087F852DCAAC9A20C324B61D /* Expecta-dummy.m */; };
+		F7E3BD700A9B2EA54BA4889E6B30DDDE /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CAEC4BC3B8CA95BC1C1EF2CB745E9DD /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8987FAEE98ABF02E6A673F128AE03AC /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = FD3C3EF001F08A60A1926DEA4D51D66D /* SEGReachability.m */; };
+		FBB05E1576EB3CB4C452FB833D420FFF /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 090D21157FB75C5150BDC8418FA959F0 /* SEGSegmentIntegration.m */; };
+		FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F6534573494625A6C51952E5E37B0BB4 /* Expecta-dummy.m */; };
+		FE6FFBB4ABCBB16C5951AA1E2EA1C1DE /* SEGAnalyticsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E624D5E9FEB26FAB5A34A5BBA34CD7A /* SEGAnalyticsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,7 +180,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
+			remoteGlobalIDString = 8056D060CDB25304FD112AB00556C3F3;
 			remoteInfo = Analytics;
 		};
 		5528BBB09FD6EA23A6A34608CC603923 /* PBXContainerItemProxy */ = {
@@ -188,14 +194,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
+			remoteGlobalIDString = 8056D060CDB25304FD112AB00556C3F3;
 			remoteInfo = Analytics;
 		};
 		B1D0C63210E1A60420D426381255CCC6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
+			remoteGlobalIDString = 8056D060CDB25304FD112AB00556C3F3;
 			remoteInfo = Analytics;
 		};
 		E1119CEA456C14FAD6ACD8BAD4B8BAD0 /* PBXContainerItemProxy */ = {
@@ -208,174 +214,180 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0298B3E429D05DB07F44F3910DA9A8CC /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
-		0324C64448608A6E80918A520EE34FB7 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
-		0381736001DA348D8834BFC871D65897 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
-		05CAB1FD23AE421837CDB508F004399F /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
-		0715583339195703602EEE41BF3519B2 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
+		010904C5B1C62609FEBC6AB1AD398F67 /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
+		01AD61A3C8301A81F2C3C95A236CBBB9 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		032983F37E7F2FF914CD0A01488C38BD /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
+		07C5CACA8660B7AC7E5393FA10891BD5 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
+		08EDFC104DBD6513B2563D134D38A2D4 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
+		090D21157FB75C5150BDC8418FA959F0 /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Pod/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
 		0A74696A57CD73BF92406B1CE6BABDEC /* libAnalytics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAnalytics.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		0B4218C263EC6361910EE95D400C6FB0 /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		0DE08B731D289E455A18859F3A70F332 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
-		107BB7AF015AC09039FCB83D812A0807 /* Analytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.xcconfig; sourceTree = "<group>"; };
+		11052C241393984D10D2BCB14682837A /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
+		11D85C17DE471463C5781E990F8F3735 /* NSData+GZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+GZIP.m"; path = "Pod/Classes/Internal/NSData+GZIP.m"; sourceTree = "<group>"; };
 		12419CC61CF19198C4B9CAA3CE8DA6D6 /* libExpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libExpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		14D6D34A0AAADCC655590C1D25E730F5 /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Pod/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
-		17D769918D41BA08AFF8B66157EAA16B /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		186B2A080B645D7968B79FE4A165F32F /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
-		1B06BA21A39C5C63CF87D068C4D60670 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		1B42FB13E27538E40FBB1F320F9D46F8 /* SEGLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGLocation.h; path = Pod/Classes/Internal/SEGLocation.h; sourceTree = "<group>"; };
-		1E9E4F16FB96F6B1B03743ED69515CD5 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
-		242D48173DA1A1E589003C59702FE4B1 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
-		244E2CB9325EB8C4349D0C28A33C44BF /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
-		253272B3AA6F7D7B8C42E00C11BAE9AB /* SEGAnalyticsUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsUtils.h; path = Pod/Classes/Internal/SEGAnalyticsUtils.h; sourceTree = "<group>"; };
+		1D9CDB6D4CD9DDC5069353E6CDA13577 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
+		1DB307FC4137BC83C0631235ABA838D5 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
+		1E624D5E9FEB26FAB5A34A5BBA34CD7A /* SEGAnalyticsRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsRequest.h; path = Pod/Classes/Internal/SEGAnalyticsRequest.h; sourceTree = "<group>"; };
+		1FA546A23E031D797CE9640AD73C967E /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
 		25FA9CE2C75E380E2A0AF87FBAF1BE97 /* SEGOptimizelyIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGOptimizelyIntegration.h; sourceTree = "<group>"; };
+		26F04E7558CC35C72FF99704FFDB93DA /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
 		279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		286AB0802E5856E7E34531E9F52E4DD5 /* SEGLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGLocation.m; path = Pod/Classes/Internal/SEGLocation.m; sourceTree = "<group>"; };
-		2B77E4920E457AB52A342378FAE85807 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
+		294ED2F20B00104692F1F4D173B524C4 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
+		2A63A70CD2582BAD55AE0869C8C23909 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
+		2AC4F3BABDE0E7682E31B3494802E8FC /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
 		2BBA18D1850EC615E687310F7F57137A /* SEGOptimizelyIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGOptimizelyIntegrationFactory.m; sourceTree = "<group>"; };
-		2BCCDDB8AEB518A5B4BC3486797950BB /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
-		318B214C0CBB5B67A437109326A752DD /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
-		319D79DFF7CF2597C150EF77F5B8BDDF /* Optimizely.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Optimizely.framework; sourceTree = "<group>"; };
-		34FD3BB129658F5F92B1A8A7A003B479 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
-		36B4A4B3F4EE8FBB28614B195EC7718F /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
-		36F61FE2C30D626C53561D4EEE06A1A8 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
-		3A9938DF735F61654C8EBAD10DA5D049 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
-		3C1923A70C2957662E471C4182FC68EE /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		2CA89F8E2298273E0A5A0560582E1609 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
+		2D569C5B6637A228A4D65B956D557696 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
+		2EBE032F3D929DE77852A84A0D0F24D8 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
+		2FE238F964B516A544B9BCB3F9D96846 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
+		2FE7825789011559A6BE402762A83F28 /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
+		31BAEBDD3D1CD01AB1D8704BE1E02D1B /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
+		32089C83AE0C7FDF6BFAC14CCA4FD8E3 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
+		34AF9EBAAFE994B82265D530952FAE27 /* SEGPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGPayload.h; path = Pod/Classes/Integrations/SEGPayload.h; sourceTree = "<group>"; };
+		35515136B5A0D7C8EC9258EAA738CECC /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Pod/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
+		3684A6D8F361D9CE174AB82C4F965A0D /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
+		36D3F8B5CD7112D5E0C7EC78D6CB0902 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
+		3C044919FC2E97294363C21C4E082A80 /* SEGScreenPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGScreenPayload.m; path = Pod/Classes/Integrations/SEGScreenPayload.m; sourceTree = "<group>"; };
+		3C3B86DAD63479DB5CE300673D3808AF /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
 		3C9DB8746CC4B095438E4FDD90AA94BD /* Segment-Optimizely-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Segment-Optimizely-dummy.m"; sourceTree = "<group>"; };
-		3D258AB5A8C5301A7FB35AA14F67EC0E /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Pod/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
-		3F4C12E9D220B309ED193E42EDBDE4FF /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
-		402A0FFC7DAA5190492E06B8CB353D9A /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
-		4054B6414B0EC415B58289E6AD5C5DC0 /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Pod/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
-		4167BC316233780293ADA7C9B9F11666 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
-		440267A4DF204E5F57ECC67A81968CC3 /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		441208E2B7F088B88181EA8ABA1FB246 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
-		45C9E2D6B932DFBA0D98F2F6037DE9B1 /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
-		4A2A7DCEA109B03C296AE51E457E70F3 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
-		4AAA1400BF240ED1C3A2FF3E005D8045 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
-		4BF58EF0DD0E14CEF960083DB4F80C85 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
-		4C36BF0E6A66460876DAAF293E6961DF /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		4CE8D0340B0E23EDD17E4DB34B1BDD38 /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Pod/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
-		4D27A51695046136C8B4448C98C9BAE7 /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
-		4D4D5718493EE0C3FFBA3DD21C8F042A /* SEGBluetooth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGBluetooth.h; path = Pod/Classes/Internal/SEGBluetooth.h; sourceTree = "<group>"; };
-		4D681198BE23C1B86D83F05649B07618 /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
-		4DBEDBE65A5261543E2D4E7B0CBEBC78 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
+		3CAEC4BC3B8CA95BC1C1EF2CB745E9DD /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		3E82F36A9DA5892FEF5387BC07F9894C /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
+		3EB6FB4ACCECCED37C8A8BAF870DD28A /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
+		400879EB9A3AAA9CA4DDEAB583B34D62 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
+		4188F15689EF6743D46B3C39480DF647 /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
+		44D5232BFE81021EDB083BE574F6CC7F /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Pod/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
+		4528D688226D5D93739A838C298CCF36 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
+		4A096B69CEC7C8F4BEB4F4B4A01058B2 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Pod/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
 		4E2B5431BC35F3F6F706513B97D1F1B3 /* Segment-Optimizely.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Segment-Optimizely.xcconfig"; sourceTree = "<group>"; };
-		4EAD58FA253AF023C763E0F1F7C346E0 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
-		4F7A1136AE9866B1E6C4854D579E2AC0 /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Pod/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
-		502E84BBA4C7B3E20D64064C4921CE23 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
-		50ED845FB73736D1928A270774F4354F /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
+		4F66962602F78434C77769D7D828A2AE /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		5124A9285A7DA7A2BEEB38518320951E /* Pods-Segment-Optimizely_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Optimizely_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		51B7128E4B9B0A9229E6554A01BA058B /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
-		56E24ADAD8C42B94103BA6A3F005EE87 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
-		593442D4C666A84B698D1A86D77735F3 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
+		51E48571EB0D8A325E647FABCF28A5CE /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Pod/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
+		532604FAA611174FB30F9A153B96EDD9 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
+		55D3CB13F1A774B7534A9E080CC90624 /* SEGAnalyticsUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsUtils.h; path = Pod/Classes/Internal/SEGAnalyticsUtils.h; sourceTree = "<group>"; };
+		563DD0EE1D87F5F47608D819774D3995 /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		565C035DA2537D35FC716FE8725B87E4 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
+		595D70BE490362F369AB64CB883F636A /* NSData+GZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+GZIP.h"; path = "Pod/Classes/Internal/NSData+GZIP.h"; sourceTree = "<group>"; };
+		5A06621B38722ADB1576FCFAE582AC4E /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
+		5BB20DD2E90880DEA97B07536FDE482D /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
+		5BD6A97E99ADB95781EAE1D86470EE4C /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
 		5D83C6A3306D93F4E22FA04DDF4E3C2D /* Segment-Optimizely-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Segment-Optimizely-prefix.pch"; sourceTree = "<group>"; };
+		5DA7F17ABB37B55AD0000CE7989208BE /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Pod/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
 		5DFAFDB478BB284FCA305989BA61015A /* Pods-Segment-Optimizely_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-Optimizely_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		5E1544023659E84F0EF8D7917FDBE642 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
+		5E56A0BB3DBB72671538BF14E0DE34A6 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
 		5F63FC89ED3994996C522F55523B73D3 /* SEGOptimizelyIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGOptimizelyIntegration.m; sourceTree = "<group>"; };
-		60C01D595EFBB7C616E1E7E9AD83C066 /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Pod/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
-		620B1A6AA12811DA01076E70A13F76D7 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Pod/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
-		6347BD8B873CADAC8BC66C7F643791CA /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
-		63D495760CD72CAF10D25CC7D73700AD /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
-		644872D6A1C873F1A64248B1C6EC74CB /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		67B01F527AC4A15926697108C97F7FCA /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Pod/Classes/Internal/SEGReachability.h; sourceTree = "<group>"; };
-		68707517F93C563AFED4D595B6BCE02F /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
-		68A9AEC7CF42E01E5F5CEE630C540911 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
-		6A8458CDA442816187EFCD6F17472F0C /* SEGAnalyticsRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsRequest.m; path = Pod/Classes/Internal/SEGAnalyticsRequest.m; sourceTree = "<group>"; };
-		6C54014F3B847A5EDCD84E8888097C26 /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Pod/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
+		61EEBE06EA0B804141D251CB3B5612AF /* UIViewController+SEGScreen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SEGScreen.h"; path = "Pod/Classes/Internal/UIViewController+SEGScreen.h"; sourceTree = "<group>"; };
+		62763862C2C2918191D0F725A6E8B970 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
+		63FFA70669483D6D4EE2251EC04D6E3A /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Pod/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
+		6A9D3CBF4F0B8FBB97E9FA2512096C14 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
 		6D1B5454A10431E8056837091A50ECB6 /* Pods-Segment-Optimizely_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Optimizely_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		6DE62E13087F852DCAAC9A20C324B61D /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
-		70FC5B39250B573536927ACD46A76CE2 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
-		7119DC1BECA6A3F59B13126626B6930C /* SEGPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGPayload.h; path = Pod/Classes/Integrations/SEGPayload.h; sourceTree = "<group>"; };
-		79A6AE62D69E931267C8266356CFB1D2 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
-		7B8D9CF7D379CE13739E69B2554A89C3 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
-		7E53A8EA6AEAB2F9184270EF46FF9EFD /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		7E8D7892C7CEE19A26BBD37B194F8D53 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		83658D3D5E52D40F772336A71661F23F /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
-		87CE9D3DA8656A383F94B5F97A3512A2 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
+		6D9B9478DE1C4CFC3115D3C296526294 /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Pod/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
+		6DB25922404D5DD857878AEAFEB1136D /* SEGBluetooth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGBluetooth.m; path = Pod/Classes/Internal/SEGBluetooth.m; sourceTree = "<group>"; };
+		6DB93C25529BF8C411C89D9E56154151 /* UIViewController+SEGScreen.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SEGScreen.m"; path = "Pod/Classes/Internal/UIViewController+SEGScreen.m"; sourceTree = "<group>"; };
+		737DF3454379CA83979D3ABF63224EA8 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
+		76F3820E305C6E4A49A28057C699882F /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
+		77851003AA523D040ED81A63E97ED37E /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
+		78CBE6ED70FDB2D1968E22F43A227C29 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
+		795BF5CFADA760A6831262C85D951B44 /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
+		7DBBB0A7CF97C484C98D6ABF97F8D27E /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
+		7F85BEA20FF32D708FD9B03009E01CC4 /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Pod/Classes/Internal/SEGReachability.h; sourceTree = "<group>"; };
+		81641943666D862D21CAE95DCFD6C028 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
+		82452606A3149F30F3AA2C495803E764 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
+		844EBBF2DB6ADFD22ADBCDBEFCE370B4 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
+		88132AADBA174FF46EA3EE7B51E11F75 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
+		89367FC7978F8000C8319FD6F14AE600 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
+		8A20186DC203A1F8F6E2D65810EF6C6B /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
+		8AB62FC69799E38145E9FE1390F20488 /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
 		8B1B01DBEE6960A1F55641A3AC931D0E /* SEGOptimizelyIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGOptimizelyIntegrationFactory.h; sourceTree = "<group>"; };
+		8CDC8257F6AFD5627FE675001B9B8F79 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
 		9002CBA3E61320D23CFA6C97767185D2 /* Pods-Segment-Optimizely_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-Optimizely_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		91E54AAF582A9DD46AEB656F556474C7 /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
-		9265BD66D7D71D58B2CA48606B24310E /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Pod/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
-		92B3E790E9A25308F0D5B0DFC9F1172D /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		93647A2472225B8562A58EB076032DAC /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
-		94697A97C0499B76466BDAB7DB0EB169 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
+		9044E29D277B5CC5BDAC489095F96678 /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Pod/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
+		9103A2A09C41DEECDC77CBCC7D5DAB74 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
+		916958303CF130BF4E15B1E1C44C7EA8 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		9258F54EA01E90F23553C1F877297567 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
 		94C8F2C203D298B59D3B210BE6034604 /* libPods-Segment-Optimizely_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Optimizely_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9562ADC6B344F02FA1BFA08B4754D9E4 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		94FA446F21A14C5C6080B7E93BE21EFE /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Pod/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
+		971CDA5D9B01EE1E68612920627D4282 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
 		97CC3D74CEA210B87FA05F9A8AD25B3E /* libSegment-Optimizely.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libSegment-Optimizely.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		983697CFD574ADCB9E7A391A1C333491 /* Pods-Segment-Optimizely_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Optimizely_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		99139718A6BACA3B1356E1508C8F39DD /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
-		9963EAF1DDCA0173B5432203C55FDD0D /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
-		9977C5E263BEE03EA90BFFBB74061736 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		9C86882503A869B211AA224C57E6F79A /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
-		9DDBE2061B55E3F57516FCF2978A1625 /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Pod/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
-		9E2D701BB322BD08CE6134666C831254 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
-		9EAC803DBF4166B6FB158C5746285EE1 /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
-		9F5B8AFCE2C53DAAA1D4AD66CCDA7C73 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
-		9F9307335A85E8A0019099C1AB37F09C /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
-		A01D565F912475D47892285ECA6BA3F8 /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Pod/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
-		A05F25AA3EA485A7ABB943BF501B0209 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
-		A12B53A62FFFD93760A25EEDE51D952D /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Pod/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
-		A14449D0C3CEBADE0FB520BA1C781A47 /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		987A67DCE85070A1D995348EDF5694D2 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
+		9AA40010024D315DE96322C88735DA42 /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
+		9C07E758DC9189F2CDEA5E8C022F01AE /* Analytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.xcconfig; sourceTree = "<group>"; };
+		9FC0060866E4A94F5D3C97398FF8231B /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Pod/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
+		9FD2A195CF6D347A7BCFDAD35DF2B5AA /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
 		A376889197083F02978C07DAE71DAF2E /* Pods-Segment-Optimizely_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-Optimizely_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		A4AEDB40B6EBE1B9E4606930EB7BBD16 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
-		A4D79824A5642E7F944713C91FA200D6 /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		A5ADAEC813D5A7106930076A5B3D34F8 /* SEGBluetooth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGBluetooth.m; path = Pod/Classes/Internal/SEGBluetooth.m; sourceTree = "<group>"; };
-		A8F63A304CB8536906114FF0E4CDAA9E /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
-		AB3FE211889402FE94F4943B35EFDB2B /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
-		AF091B958E38840A17231F281F66837E /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
+		A8870AE5160CB46C2AA28ACF4CB36433 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
+		AA98737427C7A1032C4A3A6E93FBD36E /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
+		ABC5ED6050F1089A9EF61141C6197EC2 /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
+		ADADDEE6CF644657B41F2DF33AB3DE1D /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
 		AF2472A01224C0CAA7BBDBFB5FCD4F3B /* Pods-Segment-Optimizely_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Optimizely_Tests-resources.sh"; sourceTree = "<group>"; };
-		B098A6857E45554F131A3F8189A5F346 /* SEGScreenPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGScreenPayload.m; path = Pod/Classes/Integrations/SEGScreenPayload.m; sourceTree = "<group>"; };
 		B27419ED8ABA4263E9B9C9760C40446F /* Pods-Segment-Optimizely_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Optimizely_Example-frameworks.sh"; sourceTree = "<group>"; };
-		B34FB02E50CB936D89830CB027F9EE1E /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Pod/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
-		B37FD66548104858FE30171C6D67B7E7 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
-		B425BB1AC00B45F5B31218B84812DB4F /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		B53975F33C34AF5E75DD03091C4F85D0 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		B5934042AA0D1B0FE48D86CC370218B4 /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Pod/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
-		B5CBC0A3B4715C9848F175A8DEEDE3B2 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
-		B80D1FA0AF34E3A929C73C7FB66C4651 /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		B29EFBE11118B62D214188BEEACD2676 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
+		B2D1223C56ACACA8076CA684EE297C05 /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		B30113ACD2F4485609E9D13342ACF4AF /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
+		B423E47101EDB0CC51F97A299598F979 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
+		B4F519AF0DDC8A146241887439986236 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
+		B977A98AC7F5EB5CC66EFED48C2BABC8 /* SEGStoreKitTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGStoreKitTracker.m; path = Pod/Classes/Internal/SEGStoreKitTracker.m; sourceTree = "<group>"; };
+		BA235E5A23582C29F9FB804C5C021AC7 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BC63C242F3D3766D652493C227ED9922 /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
-		C1A97FB897B0C7694594BBFEE66DDB7D /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
-		C2776B5E321F98D31184D19A97A32BAC /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
+		BB9C90E08D26F49AF29F3291130B4C5C /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
+		BC78ADC14991B0EF4A7F977A710E553A /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Pod/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
+		BE35A5497B6BCDDFDA32DD702D862504 /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
+		BEE4F478C3279D1DC5090C09969C1DC0 /* SEGBluetooth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGBluetooth.h; path = Pod/Classes/Internal/SEGBluetooth.h; sourceTree = "<group>"; };
+		BF0548068FF806210542294936BD08BD /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
+		C12566A4A8D3AE966344AE005E840D61 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
+		C14B3650BA8686C4F8D0C42CCFE65431 /* SEGLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGLocation.h; path = Pod/Classes/Internal/SEGLocation.h; sourceTree = "<group>"; };
+		C1591A96BDF0D138D44EA9B76C2E2E6C /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
+		C1AAC52C78C2CEA1A715B5F90A989D1C /* Optimizely.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Optimizely.framework; sourceTree = "<group>"; };
+		C225EED69B5319A8B4464528E9EC9BAB /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
 		C2853044ABCF12F8C6F801DF4D71599D /* Pods-Segment-Optimizely_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Optimizely_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		C396B706031837181FDCE5CC7602084F /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		C3EAEA19415FF7EBAA073A6075D81E53 /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		C6D2683E1A499E13F10AD2289429888C /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
-		C8E3A8E99AFB130AAA2651890FEB7078 /* SEGAnalyticsRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsRequest.h; path = Pod/Classes/Internal/SEGAnalyticsRequest.h; sourceTree = "<group>"; };
+		C2A3B6C10152855C5D933DE13374CD19 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
+		C445EE5C0E6FB9984B8CCFB57410636C /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
+		C5186074C38F7A8415A10A37B5EEC12C /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
+		C559C72057088CC3CA122461879728CC /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		C5BC365290F150267A1C761A9967557E /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
+		C7DDD3A45660A21C6831853333BFF867 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
+		C9BA566801C95162E60801E023A6BFC8 /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
 		CA5AD4874CB9B8A71FC2997F368B2232 /* Pods-Segment-Optimizely_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Optimizely_Example.release.xcconfig"; sourceTree = "<group>"; };
 		CB91C4F851A3B14CDE98FDF4ACC0A1B5 /* Pods-Segment-Optimizely_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-Optimizely_Tests-dummy.m"; sourceTree = "<group>"; };
-		CC41603E6052A6442A0F89EE02BF3414 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
-		CF122A4D91B6733F615B196A9A460547 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
-		D15A4A7D98D7A6C838D285D843ABC8C0 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
-		D506AE952E73CD635A6319D2EED3CFE7 /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
-		D5BFB1224014C2F4FE31241DB5467629 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
-		D719E052C40A18C5C3F419E3B32A88E6 /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
+		CC5AABBA1754A29CC27823EF17C27933 /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Pod/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
+		CE475E743136595C8D21F3487A40D17D /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
+		CF7AD8466A23599845CD730623E45DEB /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
+		CF95B1A533B3179908368CF62F3FD6BD /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
+		D055171EC1A1F3B92BE4A1CC6A82C709 /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
+		D21F2E43C83A03CC604E1F6D1BA4EFC8 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
+		D24C7DE311FEC893DAEEB8737A2E58C0 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
+		D4D48CEC8BC0752AF325095F720B26CF /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Pod/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
+		D51C1BB513557F875185B60745A59C17 /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
+		D52FF053FF579F9A76BBA1CF2F25CA78 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		D6A449F5F1C2BDE1BBA8A9D71FB20278 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
+		D77AEA1601836427C63E2B6187F0C0B1 /* SEGStoreKitTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStoreKitTracker.h; path = Pod/Classes/Internal/SEGStoreKitTracker.h; sourceTree = "<group>"; };
+		D90CFA8DBC6ABCF4CA293FBE2392A7E8 /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
+		D93BBD027019BDEDC44007A499836B93 /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Pod/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
 		DB4F9DAF43118128670073EF3DE0BE95 /* Pods-Segment-Optimizely_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Optimizely_Example-resources.sh"; sourceTree = "<group>"; };
+		DB7C4909AC18A8F8F6BC48F0A86ADEF9 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		DC4B940548D948970093463F4D0347F1 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
 		DDB55C2B6284EC5E78C418B7A42EE76A /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF38826D48BE1D2FD3DDD0EE47CF00CD /* Pods-Segment-Optimizely_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-Optimizely_Example-dummy.m"; sourceTree = "<group>"; };
-		E2F3D0ECC82C69286BDB5C4F1371855A /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
-		E2FA2231028693909EDEFB4BDC98D96C /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
-		E302CF469D20505FC249F6CB5D869B49 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
+		E0B9B3E86F6895CE056089349373F21E /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
 		E317D4258090E42B55BDF5DB00721BD1 /* Pods-Segment-Optimizely_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-Optimizely_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		E4639F6C198CD90425081081908CD4A3 /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
-		E54EFA6DF743A51785BFCB7FCC81A779 /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Pod/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
-		E6E6FB0CD93C9470FABF060BD77D50FD /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		E9BD83A8E331A110DB07B995BB274C6C /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
+		E3530244B27F2AD2EFD9D837D31040F5 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
+		E3BEA0C19AB0231D1BAAB8FD16BDF8F8 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
+		E4FFA598FE8E75AC0B16CA04096E966E /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Pod/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
 		EA5716BFEAF207E5D1823CD6F54AAC1F /* libPods-Segment-Optimizely_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Optimizely_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC66943145F2DC7358ABFA49F8E44D1B /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
-		ECD92DCF672B315A64EF4E3F6CCA2EDA /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
-		EE8DFB16A45932AA6BE0978D8C0995FB /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Pod/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
-		EF76C0D7A2FEBC32B282C59D913D314D /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
-		F183F307D83E956C2EB9630A680CD8D9 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		F1D9DE4EF913C62588F8D678B4F84AA9 /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
-		F1FDD77A1259479B0BF17F8D9067920D /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
-		F4A2B55ADCFF0929DAF7E5701FDB624F /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
-		F58A5303B2824AA348AA20DC40C7FA92 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
-		F653B6B1695C00A5947990D9A13B947C /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Pod/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
-		FA7CABF7FBB4D56ABB53122992DB5F49 /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		FCF474C35D10B2698E2EC6F6340557AA /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
-		FD34E27A04D88FE7D3CBD9D0EDCF0688 /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
-		FFB4187CB67DFCE289D005A02DFB1373 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
-		FFF48FDAD61E7EFFF3CF51642D34204A /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Pod/Classes/Internal/SEGReachability.m; sourceTree = "<group>"; };
+		EB2F23591EDA36F6FD225E562AFA540C /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
+		EBBBD24A2BBBC7E14F5DB703B0C90DC4 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		EC663AB176811EE2026D7587CEB7D0F4 /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
+		ED51660FBE8D8ED03F7D52E47DD6D187 /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
+		EFFDEB523A20D120BFAF893D1AD7DBAF /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
+		F308F157CEE56FAFE74887B3616CE5B4 /* SEGLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGLocation.m; path = Pod/Classes/Internal/SEGLocation.m; sourceTree = "<group>"; };
+		F4E1FF37285A5A78CFB5711AA7766D95 /* SEGAnalyticsRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsRequest.m; path = Pod/Classes/Internal/SEGAnalyticsRequest.m; sourceTree = "<group>"; };
+		F50A5D49A088521E9A5C29AF590C5E17 /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
+		F6534573494625A6C51952E5E37B0BB4 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
+		FA28582DEA6A8933E1AA38F90AFB10EC /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
+		FA46AB517F65FC1FB879EE58BBAAFD2F /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
+		FC2FB7CF4A559F56ABC165E43C702792 /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Pod/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
+		FD3C3EF001F08A60A1926DEA4D51D66D /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Pod/Classes/Internal/SEGReachability.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,11 +408,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7220860A5419A2390473421A11D2A3A0 /* Frameworks */ = {
+		4DB3AB26DD3F020C3C41DB56DDE85038 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91716783ABA4BA9B79B0501A0CDB59D9 /* Foundation.framework in Frameworks */,
+				EEA91B5351A83B3D7937B28636A144D3 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,58 +463,92 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		24B8089DB4DB46B3CECAB6CBE862AEAB /* Frameworks */ = {
+		0C8AF77874789089189669BF2ADADA46 /* Specta */ = {
 			isa = PBXGroup;
 			children = (
-				319D79DFF7CF2597C150EF77F5B8BDDF /* Optimizely.framework */,
+				8A20186DC203A1F8F6E2D65810EF6C6B /* Specta.h */,
+				8AB62FC69799E38145E9FE1390F20488 /* SpectaDSL.h */,
+				D6A449F5F1C2BDE1BBA8A9D71FB20278 /* SpectaDSL.m */,
+				5E1544023659E84F0EF8D7917FDBE642 /* SpectaTypes.h */,
+				07C5CACA8660B7AC7E5393FA10891BD5 /* SpectaUtility.h */,
+				8CDC8257F6AFD5627FE675001B9B8F79 /* SpectaUtility.m */,
+				ED51660FBE8D8ED03F7D52E47DD6D187 /* SPTCallSite.h */,
+				2EBE032F3D929DE77852A84A0D0F24D8 /* SPTCallSite.m */,
+				D51C1BB513557F875185B60745A59C17 /* SPTCompiledExample.h */,
+				FA46AB517F65FC1FB879EE58BBAAFD2F /* SPTCompiledExample.m */,
+				EB2F23591EDA36F6FD225E562AFA540C /* SPTExample.h */,
+				1FA546A23E031D797CE9640AD73C967E /* SPTExample.m */,
+				31BAEBDD3D1CD01AB1D8704BE1E02D1B /* SPTExampleGroup.h */,
+				3C3B86DAD63479DB5CE300673D3808AF /* SPTExampleGroup.m */,
+				D52FF053FF579F9A76BBA1CF2F25CA78 /* SPTExcludeGlobalBeforeAfterEach.h */,
+				4F66962602F78434C77769D7D828A2AE /* SPTGlobalBeforeAfterEach.h */,
+				DC4B940548D948970093463F4D0347F1 /* SPTSharedExampleGroups.h */,
+				C12566A4A8D3AE966344AE005E840D61 /* SPTSharedExampleGroups.m */,
+				987A67DCE85070A1D995348EDF5694D2 /* SPTSpec.h */,
+				B30113ACD2F4485609E9D13342ACF4AF /* SPTSpec.m */,
+				032983F37E7F2FF914CD0A01488C38BD /* SPTTestSuite.h */,
+				2FE7825789011559A6BE402762A83F28 /* SPTTestSuite.m */,
+				2CA89F8E2298273E0A5A0560582E1609 /* XCTest+Private.h */,
+				3CAEC4BC3B8CA95BC1C1EF2CB745E9DD /* XCTestCase+Specta.h */,
+				D055171EC1A1F3B92BE4A1CC6A82C709 /* XCTestCase+Specta.m */,
+				A6F0B75741FFC6EB266E75128FABA779 /* Support Files */,
 			);
-			name = Frameworks;
+			path = Specta;
 			sourceTree = "<group>";
 		};
-		2A3EFE02CF34093E02DB83FF6C0FE46A /* Optimizely-iOS-SDK */ = {
+		0F55572945F5268EBAD308D49E76396F /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				24B8089DB4DB46B3CECAB6CBE862AEAB /* Frameworks */,
-			);
-			path = "Optimizely-iOS-SDK";
-			sourceTree = "<group>";
-		};
-		2AC6E97D3EF7A73523F526503C84F8BB /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				9265BD66D7D71D58B2CA48606B24310E /* SEGAliasPayload.h */,
-				620B1A6AA12811DA01076E70A13F76D7 /* SEGAliasPayload.m */,
-				4CE8D0340B0E23EDD17E4DB34B1BDD38 /* SEGAnalytics.h */,
-				6C54014F3B847A5EDCD84E8888097C26 /* SEGAnalytics.m */,
-				C8E3A8E99AFB130AAA2651890FEB7078 /* SEGAnalyticsRequest.h */,
-				6A8458CDA442816187EFCD6F17472F0C /* SEGAnalyticsRequest.m */,
-				253272B3AA6F7D7B8C42E00C11BAE9AB /* SEGAnalyticsUtils.h */,
-				E54EFA6DF743A51785BFCB7FCC81A779 /* SEGAnalyticsUtils.m */,
-				4D4D5718493EE0C3FFBA3DD21C8F042A /* SEGBluetooth.h */,
-				A5ADAEC813D5A7106930076A5B3D34F8 /* SEGBluetooth.m */,
-				B34FB02E50CB936D89830CB027F9EE1E /* SEGGroupPayload.h */,
-				4054B6414B0EC415B58289E6AD5C5DC0 /* SEGGroupPayload.m */,
-				14D6D34A0AAADCC655590C1D25E730F5 /* SEGIdentifyPayload.h */,
-				A01D565F912475D47892285ECA6BA3F8 /* SEGIdentifyPayload.m */,
-				A12B53A62FFFD93760A25EEDE51D952D /* SEGIntegration.h */,
-				9DDBE2061B55E3F57516FCF2978A1625 /* SEGIntegrationFactory.h */,
-				1B42FB13E27538E40FBB1F320F9D46F8 /* SEGLocation.h */,
-				286AB0802E5856E7E34531E9F52E4DD5 /* SEGLocation.m */,
-				7119DC1BECA6A3F59B13126626B6930C /* SEGPayload.h */,
-				F653B6B1695C00A5947990D9A13B947C /* SEGPayload.m */,
-				67B01F527AC4A15926697108C97F7FCA /* SEGReachability.h */,
-				FFF48FDAD61E7EFFF3CF51642D34204A /* SEGReachability.m */,
-				EE8DFB16A45932AA6BE0978D8C0995FB /* SEGScreenPayload.h */,
-				B098A6857E45554F131A3F8189A5F346 /* SEGScreenPayload.m */,
-				B5934042AA0D1B0FE48D86CC370218B4 /* SEGSegmentIntegration.h */,
-				60C01D595EFBB7C616E1E7E9AD83C066 /* SEGSegmentIntegration.m */,
-				FD34E27A04D88FE7D3CBD9D0EDCF0688 /* SEGSegmentIntegrationFactory.h */,
-				BC63C242F3D3766D652493C227ED9922 /* SEGSegmentIntegrationFactory.m */,
-				4F7A1136AE9866B1E6C4854D579E2AC0 /* SEGTrackPayload.h */,
-				3D258AB5A8C5301A7FB35AA14F67EC0E /* SEGTrackPayload.m */,
-				6E973F96BBE0BDCB58D60B126EF1C0B0 /* Support Files */,
+				595D70BE490362F369AB64CB883F636A /* NSData+GZIP.h */,
+				11D85C17DE471463C5781E990F8F3735 /* NSData+GZIP.m */,
+				35515136B5A0D7C8EC9258EAA738CECC /* SEGAliasPayload.h */,
+				4A096B69CEC7C8F4BEB4F4B4A01058B2 /* SEGAliasPayload.m */,
+				44D5232BFE81021EDB083BE574F6CC7F /* SEGAnalytics.h */,
+				BC78ADC14991B0EF4A7F977A710E553A /* SEGAnalytics.m */,
+				1E624D5E9FEB26FAB5A34A5BBA34CD7A /* SEGAnalyticsRequest.h */,
+				F4E1FF37285A5A78CFB5711AA7766D95 /* SEGAnalyticsRequest.m */,
+				55D3CB13F1A774B7534A9E080CC90624 /* SEGAnalyticsUtils.h */,
+				63FFA70669483D6D4EE2251EC04D6E3A /* SEGAnalyticsUtils.m */,
+				BEE4F478C3279D1DC5090C09969C1DC0 /* SEGBluetooth.h */,
+				6DB25922404D5DD857878AEAFEB1136D /* SEGBluetooth.m */,
+				51E48571EB0D8A325E647FABCF28A5CE /* SEGGroupPayload.h */,
+				FC2FB7CF4A559F56ABC165E43C702792 /* SEGGroupPayload.m */,
+				E4FFA598FE8E75AC0B16CA04096E966E /* SEGIdentifyPayload.h */,
+				CC5AABBA1754A29CC27823EF17C27933 /* SEGIdentifyPayload.m */,
+				D4D48CEC8BC0752AF325095F720B26CF /* SEGIntegration.h */,
+				9044E29D277B5CC5BDAC489095F96678 /* SEGIntegrationFactory.h */,
+				C14B3650BA8686C4F8D0C42CCFE65431 /* SEGLocation.h */,
+				F308F157CEE56FAFE74887B3616CE5B4 /* SEGLocation.m */,
+				34AF9EBAAFE994B82265D530952FAE27 /* SEGPayload.h */,
+				94FA446F21A14C5C6080B7E93BE21EFE /* SEGPayload.m */,
+				7F85BEA20FF32D708FD9B03009E01CC4 /* SEGReachability.h */,
+				FD3C3EF001F08A60A1926DEA4D51D66D /* SEGReachability.m */,
+				6D9B9478DE1C4CFC3115D3C296526294 /* SEGScreenPayload.h */,
+				3C044919FC2E97294363C21C4E082A80 /* SEGScreenPayload.m */,
+				9FC0060866E4A94F5D3C97398FF8231B /* SEGSegmentIntegration.h */,
+				090D21157FB75C5150BDC8418FA959F0 /* SEGSegmentIntegration.m */,
+				EC663AB176811EE2026D7587CEB7D0F4 /* SEGSegmentIntegrationFactory.h */,
+				D90CFA8DBC6ABCF4CA293FBE2392A7E8 /* SEGSegmentIntegrationFactory.m */,
+				D77AEA1601836427C63E2B6187F0C0B1 /* SEGStoreKitTracker.h */,
+				B977A98AC7F5EB5CC66EFED48C2BABC8 /* SEGStoreKitTracker.m */,
+				D93BBD027019BDEDC44007A499836B93 /* SEGTrackPayload.h */,
+				5DA7F17ABB37B55AD0000CE7989208BE /* SEGTrackPayload.m */,
+				61EEBE06EA0B804141D251CB3B5612AF /* UIViewController+SEGScreen.h */,
+				6DB93C25529BF8C411C89D9E56154151 /* UIViewController+SEGScreen.m */,
+				18154561E8D0D87FC28914B77B139BB0 /* Support Files */,
 			);
 			path = Analytics;
+			sourceTree = "<group>";
+		};
+		18154561E8D0D87FC28914B77B139BB0 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				9C07E758DC9189F2CDEA5E8C022F01AE /* Analytics.xcconfig */,
+				77851003AA523D040ED81A63E97ED37E /* Analytics-dummy.m */,
+				010904C5B1C62609FEBC6AB1AD398F67 /* Analytics-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Analytics";
 			sourceTree = "<group>";
 		};
 		2BAD572D8C7A8F7F1E58151422D09186 /* Pod */ = {
@@ -526,93 +572,20 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		3E3DBBD27D0A83E954EF7035FAA7EFC5 /* Expecta */ = {
-			isa = PBXGroup;
-			children = (
-				4DBEDBE65A5261543E2D4E7B0CBEBC78 /* EXPBlockDefinedMatcher.h */,
-				36F61FE2C30D626C53561D4EEE06A1A8 /* EXPBlockDefinedMatcher.m */,
-				05CAB1FD23AE421837CDB508F004399F /* EXPDefines.h */,
-				A8F63A304CB8536906114FF0E4CDAA9E /* EXPDoubleTuple.h */,
-				7E8D7892C7CEE19A26BBD37B194F8D53 /* EXPDoubleTuple.m */,
-				4D681198BE23C1B86D83F05649B07618 /* Expecta.h */,
-				D506AE952E73CD635A6319D2EED3CFE7 /* ExpectaObject.h */,
-				B425BB1AC00B45F5B31218B84812DB4F /* ExpectaObject.m */,
-				3C1923A70C2957662E471C4182FC68EE /* ExpectaSupport.h */,
-				0298B3E429D05DB07F44F3910DA9A8CC /* ExpectaSupport.m */,
-				318B214C0CBB5B67A437109326A752DD /* EXPExpect.h */,
-				AF091B958E38840A17231F281F66837E /* EXPExpect.m */,
-				50ED845FB73736D1928A270774F4354F /* EXPFloatTuple.h */,
-				34FD3BB129658F5F92B1A8A7A003B479 /* EXPFloatTuple.m */,
-				51B7128E4B9B0A9229E6554A01BA058B /* EXPMatcher.h */,
-				440267A4DF204E5F57ECC67A81968CC3 /* EXPMatcherHelpers.h */,
-				87CE9D3DA8656A383F94B5F97A3512A2 /* EXPMatcherHelpers.m */,
-				70FC5B39250B573536927ACD46A76CE2 /* EXPMatchers.h */,
-				3A9938DF735F61654C8EBAD10DA5D049 /* EXPMatchers+beCloseTo.h */,
-				2B77E4920E457AB52A342378FAE85807 /* EXPMatchers+beCloseTo.m */,
-				9F9307335A85E8A0019099C1AB37F09C /* EXPMatchers+beFalsy.h */,
-				4EAD58FA253AF023C763E0F1F7C346E0 /* EXPMatchers+beFalsy.m */,
-				68A9AEC7CF42E01E5F5CEE630C540911 /* EXPMatchers+beginWith.h */,
-				D5BFB1224014C2F4FE31241DB5467629 /* EXPMatchers+beginWith.m */,
-				3F4C12E9D220B309ED193E42EDBDE4FF /* EXPMatchers+beGreaterThan.h */,
-				0DE08B731D289E455A18859F3A70F332 /* EXPMatchers+beGreaterThan.m */,
-				186B2A080B645D7968B79FE4A165F32F /* EXPMatchers+beGreaterThanOrEqualTo.h */,
-				F58A5303B2824AA348AA20DC40C7FA92 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
-				68707517F93C563AFED4D595B6BCE02F /* EXPMatchers+beIdenticalTo.h */,
-				94697A97C0499B76466BDAB7DB0EB169 /* EXPMatchers+beIdenticalTo.m */,
-				B5CBC0A3B4715C9848F175A8DEEDE3B2 /* EXPMatchers+beInstanceOf.h */,
-				9EAC803DBF4166B6FB158C5746285EE1 /* EXPMatchers+beInstanceOf.m */,
-				EC66943145F2DC7358ABFA49F8E44D1B /* EXPMatchers+beInTheRangeOf.h */,
-				E2FA2231028693909EDEFB4BDC98D96C /* EXPMatchers+beInTheRangeOf.m */,
-				B37FD66548104858FE30171C6D67B7E7 /* EXPMatchers+beKindOf.h */,
-				B53975F33C34AF5E75DD03091C4F85D0 /* EXPMatchers+beKindOf.m */,
-				C2776B5E321F98D31184D19A97A32BAC /* EXPMatchers+beLessThan.h */,
-				593442D4C666A84B698D1A86D77735F3 /* EXPMatchers+beLessThan.m */,
-				AB3FE211889402FE94F4943B35EFDB2B /* EXPMatchers+beLessThanOrEqualTo.h */,
-				ECD92DCF672B315A64EF4E3F6CCA2EDA /* EXPMatchers+beLessThanOrEqualTo.m */,
-				7B8D9CF7D379CE13739E69B2554A89C3 /* EXPMatchers+beNil.h */,
-				644872D6A1C873F1A64248B1C6EC74CB /* EXPMatchers+beNil.m */,
-				E6E6FB0CD93C9470FABF060BD77D50FD /* EXPMatchers+beSubclassOf.h */,
-				4AAA1400BF240ED1C3A2FF3E005D8045 /* EXPMatchers+beSubclassOf.m */,
-				D15A4A7D98D7A6C838D285D843ABC8C0 /* EXPMatchers+beSupersetOf.h */,
-				17D769918D41BA08AFF8B66157EAA16B /* EXPMatchers+beSupersetOf.m */,
-				A14449D0C3CEBADE0FB520BA1C781A47 /* EXPMatchers+beTruthy.h */,
-				242D48173DA1A1E589003C59702FE4B1 /* EXPMatchers+beTruthy.m */,
-				502E84BBA4C7B3E20D64064C4921CE23 /* EXPMatchers+conformTo.h */,
-				CC41603E6052A6442A0F89EE02BF3414 /* EXPMatchers+conformTo.m */,
-				4167BC316233780293ADA7C9B9F11666 /* EXPMatchers+contain.h */,
-				9C86882503A869B211AA224C57E6F79A /* EXPMatchers+contain.m */,
-				63D495760CD72CAF10D25CC7D73700AD /* EXPMatchers+endWith.h */,
-				EF76C0D7A2FEBC32B282C59D913D314D /* EXPMatchers+endWith.m */,
-				2BCCDDB8AEB518A5B4BC3486797950BB /* EXPMatchers+equal.h */,
-				79A6AE62D69E931267C8266356CFB1D2 /* EXPMatchers+equal.m */,
-				9E2D701BB322BD08CE6134666C831254 /* EXPMatchers+haveCountOf.h */,
-				9F5B8AFCE2C53DAAA1D4AD66CCDA7C73 /* EXPMatchers+haveCountOf.m */,
-				B80D1FA0AF34E3A929C73C7FB66C4651 /* EXPMatchers+match.h */,
-				E302CF469D20505FC249F6CB5D869B49 /* EXPMatchers+match.m */,
-				402A0FFC7DAA5190492E06B8CB353D9A /* EXPMatchers+postNotification.h */,
-				A4D79824A5642E7F944713C91FA200D6 /* EXPMatchers+postNotification.m */,
-				9562ADC6B344F02FA1BFA08B4754D9E4 /* EXPMatchers+raise.h */,
-				F1FDD77A1259479B0BF17F8D9067920D /* EXPMatchers+raise.m */,
-				7E53A8EA6AEAB2F9184270EF46FF9EFD /* EXPMatchers+raiseWithReason.h */,
-				CF122A4D91B6733F615B196A9A460547 /* EXPMatchers+raiseWithReason.m */,
-				0381736001DA348D8834BFC871D65897 /* EXPMatchers+respondTo.h */,
-				1B06BA21A39C5C63CF87D068C4D60670 /* EXPMatchers+respondTo.m */,
-				56E24ADAD8C42B94103BA6A3F005EE87 /* EXPUnsupportedObject.h */,
-				D719E052C40A18C5C3F419E3B32A88E6 /* EXPUnsupportedObject.m */,
-				93647A2472225B8562A58EB076032DAC /* NSObject+Expecta.h */,
-				1E9E4F16FB96F6B1B03743ED69515CD5 /* NSValue+Expecta.h */,
-				0324C64448608A6E80918A520EE34FB7 /* NSValue+Expecta.m */,
-				5D8FD8714BB694B6AF6B9C5127E9C13A /* Support Files */,
-			);
-			path = Expecta;
-			sourceTree = "<group>";
-		};
 		433CD3331B6C3787F473C941B61FC68F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				0C6B012983F9FEF8CC65C1318F5F090C /* iOS */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		49CB363E3348FC3B1C15B29154929699 /* Optimizely-iOS-SDK */ = {
+			isa = PBXGroup;
+			children = (
+				F46D7111C6BFE87C69520AC5B326326B /* Frameworks */,
+			);
+			path = "Optimizely-iOS-SDK";
 			sourceTree = "<group>";
 		};
 		4EB1A6BCB619CEAA185BA2EA46232DE3 /* Pods-Segment-Optimizely_Tests */ = {
@@ -628,17 +601,6 @@
 			);
 			name = "Pods-Segment-Optimizely_Tests";
 			path = "Target Support Files/Pods-Segment-Optimizely_Tests";
-			sourceTree = "<group>";
-		};
-		5D8FD8714BB694B6AF6B9C5127E9C13A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				4D27A51695046136C8B4448C98C9BAE7 /* Expecta.xcconfig */,
-				6DE62E13087F852DCAAC9A20C324B61D /* Expecta-dummy.m */,
-				A4AEDB40B6EBE1B9E4606930EB7BBD16 /* Expecta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Expecta";
 			sourceTree = "<group>";
 		};
 		611126FFFF3A05496A674887DFE413FF /* Support Files */ = {
@@ -667,68 +629,13 @@
 			path = "Target Support Files/Pods-Segment-Optimizely_Example";
 			sourceTree = "<group>";
 		};
-		6E973F96BBE0BDCB58D60B126EF1C0B0 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				107BB7AF015AC09039FCB83D812A0807 /* Analytics.xcconfig */,
-				F1D9DE4EF913C62588F8D678B4F84AA9 /* Analytics-dummy.m */,
-				45C9E2D6B932DFBA0D98F2F6037DE9B1 /* Analytics-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Analytics";
-			sourceTree = "<group>";
-		};
-		6F98C5800B02C6405D80C993FEF4FD61 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				4A2A7DCEA109B03C296AE51E457E70F3 /* Specta.xcconfig */,
-				36B4A4B3F4EE8FBB28614B195EC7718F /* Specta-dummy.m */,
-				E4639F6C198CD90425081081908CD4A3 /* Specta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Specta";
-			sourceTree = "<group>";
-		};
-		712A732A7C2E113E656EFC3E9F9929AE /* Specta */ = {
-			isa = PBXGroup;
-			children = (
-				441208E2B7F088B88181EA8ABA1FB246 /* Specta.h */,
-				99139718A6BACA3B1356E1508C8F39DD /* SpectaDSL.h */,
-				9963EAF1DDCA0173B5432203C55FDD0D /* SpectaDSL.m */,
-				83658D3D5E52D40F772336A71661F23F /* SpectaTypes.h */,
-				6347BD8B873CADAC8BC66C7F643791CA /* SpectaUtility.h */,
-				FCF474C35D10B2698E2EC6F6340557AA /* SpectaUtility.m */,
-				FA7CABF7FBB4D56ABB53122992DB5F49 /* SPTCallSite.h */,
-				F183F307D83E956C2EB9630A680CD8D9 /* SPTCallSite.m */,
-				C1A97FB897B0C7694594BBFEE66DDB7D /* SPTCompiledExample.h */,
-				C6D2683E1A499E13F10AD2289429888C /* SPTCompiledExample.m */,
-				0715583339195703602EEE41BF3519B2 /* SPTExample.h */,
-				0B4218C263EC6361910EE95D400C6FB0 /* SPTExample.m */,
-				244E2CB9325EB8C4349D0C28A33C44BF /* SPTExampleGroup.h */,
-				C3EAEA19415FF7EBAA073A6075D81E53 /* SPTExampleGroup.m */,
-				92B3E790E9A25308F0D5B0DFC9F1172D /* SPTExcludeGlobalBeforeAfterEach.h */,
-				C396B706031837181FDCE5CC7602084F /* SPTGlobalBeforeAfterEach.h */,
-				E9BD83A8E331A110DB07B995BB274C6C /* SPTSharedExampleGroups.h */,
-				F4A2B55ADCFF0929DAF7E5701FDB624F /* SPTSharedExampleGroups.m */,
-				A05F25AA3EA485A7ABB943BF501B0209 /* SPTSpec.h */,
-				9977C5E263BEE03EA90BFFBB74061736 /* SPTSpec.m */,
-				FFB4187CB67DFCE289D005A02DFB1373 /* SPTTestSuite.h */,
-				4C36BF0E6A66460876DAAF293E6961DF /* SPTTestSuite.m */,
-				4BF58EF0DD0E14CEF960083DB4F80C85 /* XCTest+Private.h */,
-				E2F3D0ECC82C69286BDB5C4F1371855A /* XCTestCase+Specta.h */,
-				91E54AAF582A9DD46AEB656F556474C7 /* XCTestCase+Specta.m */,
-				6F98C5800B02C6405D80C993FEF4FD61 /* Support Files */,
-			);
-			path = Specta;
-			sourceTree = "<group>";
-		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
 				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
 				83B1B113650924F629AAC3514EB28926 /* Development Pods */,
 				433CD3331B6C3787F473C941B61FC68F /* Frameworks */,
-				E5EFC0D6D02E0CD3250ECBAD31B0944E /* Pods */,
+				D10146571424897D5AF153ED7ED0B7BF /* Pods */,
 				31D3D009FAA35C9B4D79F964F7E8D2FD /* Products */,
 				A1EA03955C4339E77BD2A8FD0E4C0F4A /* Targets Support Files */,
 			);
@@ -751,6 +658,17 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
+		A6F0B75741FFC6EB266E75128FABA779 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				88132AADBA174FF46EA3EE7B51E11F75 /* Specta.xcconfig */,
+				4188F15689EF6743D46B3C39480DF647 /* Specta-dummy.m */,
+				B2D1223C56ACACA8076CA684EE297C05 /* Specta-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Specta";
+			sourceTree = "<group>";
+		};
 		A7FC20DEA3ADFA9B4084120A74C2F5FD /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -762,15 +680,115 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		E5EFC0D6D02E0CD3250ECBAD31B0944E /* Pods */ = {
+		CB108C9B2AB186007903252C53D64898 /* Expecta */ = {
 			isa = PBXGroup;
 			children = (
-				2AC6E97D3EF7A73523F526503C84F8BB /* Analytics */,
-				3E3DBBD27D0A83E954EF7035FAA7EFC5 /* Expecta */,
-				2A3EFE02CF34093E02DB83FF6C0FE46A /* Optimizely-iOS-SDK */,
-				712A732A7C2E113E656EFC3E9F9929AE /* Specta */,
+				9258F54EA01E90F23553C1F877297567 /* EXPBlockDefinedMatcher.h */,
+				A8870AE5160CB46C2AA28ACF4CB36433 /* EXPBlockDefinedMatcher.m */,
+				BA235E5A23582C29F9FB804C5C021AC7 /* EXPDefines.h */,
+				C9BA566801C95162E60801E023A6BFC8 /* EXPDoubleTuple.h */,
+				3E82F36A9DA5892FEF5387BC07F9894C /* EXPDoubleTuple.m */,
+				EFFDEB523A20D120BFAF893D1AD7DBAF /* Expecta.h */,
+				C5186074C38F7A8415A10A37B5EEC12C /* ExpectaObject.h */,
+				1D9CDB6D4CD9DDC5069353E6CDA13577 /* ExpectaObject.m */,
+				01AD61A3C8301A81F2C3C95A236CBBB9 /* ExpectaSupport.h */,
+				B4F519AF0DDC8A146241887439986236 /* ExpectaSupport.m */,
+				E0B9B3E86F6895CE056089349373F21E /* EXPExpect.h */,
+				FA28582DEA6A8933E1AA38F90AFB10EC /* EXPExpect.m */,
+				ADADDEE6CF644657B41F2DF33AB3DE1D /* EXPFloatTuple.h */,
+				971CDA5D9B01EE1E68612920627D4282 /* EXPFloatTuple.m */,
+				F50A5D49A088521E9A5C29AF590C5E17 /* EXPMatcher.h */,
+				BF0548068FF806210542294936BD08BD /* EXPMatcherHelpers.h */,
+				81641943666D862D21CAE95DCFD6C028 /* EXPMatcherHelpers.m */,
+				2FE238F964B516A544B9BCB3F9D96846 /* EXPMatchers.h */,
+				E3BEA0C19AB0231D1BAAB8FD16BDF8F8 /* EXPMatchers+beCloseTo.h */,
+				B423E47101EDB0CC51F97A299598F979 /* EXPMatchers+beCloseTo.m */,
+				C225EED69B5319A8B4464528E9EC9BAB /* EXPMatchers+beFalsy.h */,
+				89367FC7978F8000C8319FD6F14AE600 /* EXPMatchers+beFalsy.m */,
+				C7DDD3A45660A21C6831853333BFF867 /* EXPMatchers+beginWith.h */,
+				E3530244B27F2AD2EFD9D837D31040F5 /* EXPMatchers+beginWith.m */,
+				2D569C5B6637A228A4D65B956D557696 /* EXPMatchers+beGreaterThan.h */,
+				08EDFC104DBD6513B2563D134D38A2D4 /* EXPMatchers+beGreaterThan.m */,
+				82452606A3149F30F3AA2C495803E764 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
+				9103A2A09C41DEECDC77CBCC7D5DAB74 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
+				11052C241393984D10D2BCB14682837A /* EXPMatchers+beIdenticalTo.h */,
+				3EB6FB4ACCECCED37C8A8BAF870DD28A /* EXPMatchers+beIdenticalTo.m */,
+				294ED2F20B00104692F1F4D173B524C4 /* EXPMatchers+beInstanceOf.h */,
+				AA98737427C7A1032C4A3A6E93FBD36E /* EXPMatchers+beInstanceOf.m */,
+				844EBBF2DB6ADFD22ADBCDBEFCE370B4 /* EXPMatchers+beInTheRangeOf.h */,
+				C1591A96BDF0D138D44EA9B76C2E2E6C /* EXPMatchers+beInTheRangeOf.m */,
+				76F3820E305C6E4A49A28057C699882F /* EXPMatchers+beKindOf.h */,
+				36D3F8B5CD7112D5E0C7EC78D6CB0902 /* EXPMatchers+beKindOf.m */,
+				D21F2E43C83A03CC604E1F6D1BA4EFC8 /* EXPMatchers+beLessThan.h */,
+				2A63A70CD2582BAD55AE0869C8C23909 /* EXPMatchers+beLessThan.m */,
+				3684A6D8F361D9CE174AB82C4F965A0D /* EXPMatchers+beLessThanOrEqualTo.h */,
+				5BD6A97E99ADB95781EAE1D86470EE4C /* EXPMatchers+beLessThanOrEqualTo.m */,
+				2AC4F3BABDE0E7682E31B3494802E8FC /* EXPMatchers+beNil.h */,
+				BE35A5497B6BCDDFDA32DD702D862504 /* EXPMatchers+beNil.m */,
+				565C035DA2537D35FC716FE8725B87E4 /* EXPMatchers+beSubclassOf.h */,
+				C445EE5C0E6FB9984B8CCFB57410636C /* EXPMatchers+beSubclassOf.m */,
+				C5BC365290F150267A1C761A9967557E /* EXPMatchers+beSupersetOf.h */,
+				78CBE6ED70FDB2D1968E22F43A227C29 /* EXPMatchers+beSupersetOf.m */,
+				C559C72057088CC3CA122461879728CC /* EXPMatchers+beTruthy.h */,
+				EBBBD24A2BBBC7E14F5DB703B0C90DC4 /* EXPMatchers+beTruthy.m */,
+				62763862C2C2918191D0F725A6E8B970 /* EXPMatchers+conformTo.h */,
+				CE475E743136595C8D21F3487A40D17D /* EXPMatchers+conformTo.m */,
+				B29EFBE11118B62D214188BEEACD2676 /* EXPMatchers+contain.h */,
+				532604FAA611174FB30F9A153B96EDD9 /* EXPMatchers+contain.m */,
+				9AA40010024D315DE96322C88735DA42 /* EXPMatchers+endWith.h */,
+				737DF3454379CA83979D3ABF63224EA8 /* EXPMatchers+endWith.m */,
+				26F04E7558CC35C72FF99704FFDB93DA /* EXPMatchers+equal.h */,
+				6A9D3CBF4F0B8FBB97E9FA2512096C14 /* EXPMatchers+equal.m */,
+				1DB307FC4137BC83C0631235ABA838D5 /* EXPMatchers+haveCountOf.h */,
+				CF95B1A533B3179908368CF62F3FD6BD /* EXPMatchers+haveCountOf.m */,
+				563DD0EE1D87F5F47608D819774D3995 /* EXPMatchers+match.h */,
+				BB9C90E08D26F49AF29F3291130B4C5C /* EXPMatchers+match.m */,
+				400879EB9A3AAA9CA4DDEAB583B34D62 /* EXPMatchers+postNotification.h */,
+				795BF5CFADA760A6831262C85D951B44 /* EXPMatchers+postNotification.m */,
+				916958303CF130BF4E15B1E1C44C7EA8 /* EXPMatchers+raise.h */,
+				5BB20DD2E90880DEA97B07536FDE482D /* EXPMatchers+raise.m */,
+				5A06621B38722ADB1576FCFAE582AC4E /* EXPMatchers+raiseWithReason.h */,
+				4528D688226D5D93739A838C298CCF36 /* EXPMatchers+raiseWithReason.m */,
+				D24C7DE311FEC893DAEEB8737A2E58C0 /* EXPMatchers+respondTo.h */,
+				7DBBB0A7CF97C484C98D6ABF97F8D27E /* EXPMatchers+respondTo.m */,
+				9FD2A195CF6D347A7BCFDAD35DF2B5AA /* EXPUnsupportedObject.h */,
+				ABC5ED6050F1089A9EF61141C6197EC2 /* EXPUnsupportedObject.m */,
+				CF7AD8466A23599845CD730623E45DEB /* NSObject+Expecta.h */,
+				C2A3B6C10152855C5D933DE13374CD19 /* NSValue+Expecta.h */,
+				5E56A0BB3DBB72671538BF14E0DE34A6 /* NSValue+Expecta.m */,
+				DF89739897941DB493D4F1A51EE08E9C /* Support Files */,
+			);
+			path = Expecta;
+			sourceTree = "<group>";
+		};
+		D10146571424897D5AF153ED7ED0B7BF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0F55572945F5268EBAD308D49E76396F /* Analytics */,
+				CB108C9B2AB186007903252C53D64898 /* Expecta */,
+				49CB363E3348FC3B1C15B29154929699 /* Optimizely-iOS-SDK */,
+				0C8AF77874789089189669BF2ADADA46 /* Specta */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		DF89739897941DB493D4F1A51EE08E9C /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				32089C83AE0C7FDF6BFAC14CCA4FD8E3 /* Expecta.xcconfig */,
+				F6534573494625A6C51952E5E37B0BB4 /* Expecta-dummy.m */,
+				DB7C4909AC18A8F8F6BC48F0A86ADEF9 /* Expecta-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Expecta";
+			sourceTree = "<group>";
+		};
+		F46D7111C6BFE87C69520AC5B326326B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C1AAC52C78C2CEA1A715B5F90A989D1C /* Optimizely.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -782,6 +800,32 @@
 			files = (
 				28880CE27E58C9F9781B2448C4D3C874 /* SEGOptimizelyIntegration.h in Headers */,
 				4CE7CB117822A3267FD51C0A4DDEFF22 /* SEGOptimizelyIntegrationFactory.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		831C2BAF39FCF285CF1A03921A1DF00E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5849D7DCDF2B79E22AD4F96D083B08F1 /* NSData+GZIP.h in Headers */,
+				4B008984AEDE4680E20819C62BBD57FA /* SEGAliasPayload.h in Headers */,
+				3EBFA024D42A3181FB7BFF0876370EC0 /* SEGAnalytics.h in Headers */,
+				FE6FFBB4ABCBB16C5951AA1E2EA1C1DE /* SEGAnalyticsRequest.h in Headers */,
+				8AAADEF33FFB6F98FE49308C76DF3D68 /* SEGAnalyticsUtils.h in Headers */,
+				88A92561909149ACDC271FFCFCC730DA /* SEGBluetooth.h in Headers */,
+				CF8127147AC2429245DBCE326522F7C5 /* SEGGroupPayload.h in Headers */,
+				46DD92E53969E586C5AF66929893E005 /* SEGIdentifyPayload.h in Headers */,
+				BC5E5FB01C96BFA0A4DC7758DA9FCE32 /* SEGIntegration.h in Headers */,
+				D595F164BCCDCAEAA4BED14480EBE0F2 /* SEGIntegrationFactory.h in Headers */,
+				DE9A17A41AA556F8C10513C19FA69035 /* SEGLocation.h in Headers */,
+				8FA4F228A479384C25FFED7BB936CF0A /* SEGPayload.h in Headers */,
+				F59DD31DAB3A1838402C4E16012E9433 /* SEGReachability.h in Headers */,
+				E3D5F81DAF9C61EBC3247111A7FDC8A4 /* SEGScreenPayload.h in Headers */,
+				A1A90BFD7673DC790DF7B9BCFD1CBE44 /* SEGSegmentIntegration.h in Headers */,
+				C9B7C6A21989F6B0592618962A785749 /* SEGSegmentIntegrationFactory.h in Headers */,
+				21F35874229FAC9619E1B4AEA0E4E259 /* SEGStoreKitTracker.h in Headers */,
+				00261FFBC13BECCACD6B764AE2A193E7 /* SEGTrackPayload.h in Headers */,
+				05CEE7001DE28EFC6E052322F6E60818 /* UIViewController+SEGScreen.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -853,29 +897,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EFC9C5C646400A8B60584BB8E9857236 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E617E37B8DE4B930EC91E78E7B804A9C /* SEGAliasPayload.h in Headers */,
-				2F824EA28F819F2E4A9E6D31E14D0603 /* SEGAnalytics.h in Headers */,
-				98A22457F5E28CAF0B7E113A6D4142A1 /* SEGAnalyticsRequest.h in Headers */,
-				901C95FA513F8BEC6992EE457A527DE1 /* SEGAnalyticsUtils.h in Headers */,
-				539C2C0907CA46CC4DE78E19B1AFFA8E /* SEGBluetooth.h in Headers */,
-				F6A5E9881D67168D9B9BFA5FCD834596 /* SEGGroupPayload.h in Headers */,
-				EF305FCB32346C76431C1202E7AD467B /* SEGIdentifyPayload.h in Headers */,
-				25BBDA674BE9447D354412C79BF4B16C /* SEGIntegration.h in Headers */,
-				BC021CC978BE68B2BE0A690878FB54AF /* SEGIntegrationFactory.h in Headers */,
-				41D47B37FDEA46945606C39C44042D8C /* SEGLocation.h in Headers */,
-				B87904014217EC9142A60100E6D363E3 /* SEGPayload.h in Headers */,
-				DAC08D09C7E4411C8B01CD2FCFCD247B /* SEGReachability.h in Headers */,
-				6CBB0742821FD4D346404011AE148582 /* SEGScreenPayload.h in Headers */,
-				F280BEB32C116B6249D42E50A697B04B /* SEGSegmentIntegration.h in Headers */,
-				26FDD94D57A937677D2A42E53E7DBD7A /* SEGSegmentIntegrationFactory.h in Headers */,
-				DD7BED725086CF410512F736DE7AA95B /* SEGTrackPayload.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -934,6 +955,23 @@
 			productReference = 97CC3D74CEA210B87FA05F9A8AD25B3E /* libSegment-Optimizely.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		8056D060CDB25304FD112AB00556C3F3 /* Analytics */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2AC10DFCC3C4BD299187A5E47F0035AE /* Build configuration list for PBXNativeTarget "Analytics" */;
+			buildPhases = (
+				834C4AD30AE9140481E81141C625184A /* Sources */,
+				4DB3AB26DD3F020C3C41DB56DDE85038 /* Frameworks */,
+				831C2BAF39FCF285CF1A03921A1DF00E /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Analytics;
+			productName = Analytics;
+			productReference = 0A74696A57CD73BF92406B1CE6BABDEC /* libAnalytics.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		822328640408DD917E5333CB2BCF2329 /* Specta */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 53965F0FE44CFAA8C28C6CDAF25420C6 /* Build configuration list for PBXNativeTarget "Specta" */;
@@ -949,23 +987,6 @@
 			name = Specta;
 			productName = Specta;
 			productReference = DDB55C2B6284EC5E78C418B7A42EE76A /* libSpecta.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D69A20A8681184C1F18D69A2BB644717 /* Build configuration list for PBXNativeTarget "Analytics" */;
-			buildPhases = (
-				EF6D2DF45C8F0BE6ED157435C762B99A /* Sources */,
-				7220860A5419A2390473421A11D2A3A0 /* Frameworks */,
-				EFC9C5C646400A8B60584BB8E9857236 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Analytics;
-			productName = Analytics;
-			productReference = 0A74696A57CD73BF92406B1CE6BABDEC /* libAnalytics.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F61631E5AD6B227AAB3213EFD5E9BF7E /* Pods-Segment-Optimizely_Example */ = {
@@ -1007,7 +1028,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */,
+				8056D060CDB25304FD112AB00556C3F3 /* Analytics */,
 				2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */,
 				F61631E5AD6B227AAB3213EFD5E9BF7E /* Pods-Segment-Optimizely_Example */,
 				05440B176A384C48542E405086573A42 /* Pods-Segment-Optimizely_Tests */,
@@ -1060,6 +1081,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		834C4AD30AE9140481E81141C625184A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A95CA22842AC8E33798682B6B180CB86 /* Analytics-dummy.m in Sources */,
+				A39FDF4EB81E6E583D65DBB1E73EDE96 /* NSData+GZIP.m in Sources */,
+				710616E865E2AE52C4CFA7EBBAC84FA9 /* SEGAliasPayload.m in Sources */,
+				3B7A251527E2D0A8B75B00B3C389EEEA /* SEGAnalytics.m in Sources */,
+				EBAE9350B7A6F0A16D89E32EE4EB90CE /* SEGAnalyticsRequest.m in Sources */,
+				18BBCADDC3F815317F973D413D2CD648 /* SEGAnalyticsUtils.m in Sources */,
+				345DF8E2A74A614DBAEDED37B9F97D32 /* SEGBluetooth.m in Sources */,
+				D65C50CF7D039E7FE056192D3B335C31 /* SEGGroupPayload.m in Sources */,
+				3BF5D4402A44F82F26C3B59C6F8D4421 /* SEGIdentifyPayload.m in Sources */,
+				46390BE9EE31B6BF29D89D467F9936D1 /* SEGLocation.m in Sources */,
+				532CD209E5D9A1699BC51D1FCBFAF79D /* SEGPayload.m in Sources */,
+				F8987FAEE98ABF02E6A673F128AE03AC /* SEGReachability.m in Sources */,
+				56AE1A75484F81A02706C56E80C836E0 /* SEGScreenPayload.m in Sources */,
+				FBB05E1576EB3CB4C452FB833D420FFF /* SEGSegmentIntegration.m in Sources */,
+				DAC14309ED34D3C40EF7EB12FF1C657B /* SEGSegmentIntegrationFactory.m in Sources */,
+				22E2AD61FEB3923D64F8283D90A4F5D0 /* SEGStoreKitTracker.m in Sources */,
+				0959BF3A9EA8DDCD91BDD6C204C99746 /* SEGTrackPayload.m in Sources */,
+				DAE57F72A04F702C985AE999C3B01CBC /* UIViewController+SEGScreen.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8A49DC3024A25FAB80B8E0098BD33E55 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1075,28 +1121,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				994BB76453C59EEC88A7130423CB3912 /* Pods-Segment-Optimizely_Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EF6D2DF45C8F0BE6ED157435C762B99A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				486B65BB914388EA36C58304C6039F1F /* Analytics-dummy.m in Sources */,
-				0EBFCC5B0D8267DB953A68498EC7D758 /* SEGAliasPayload.m in Sources */,
-				8F8B382D1231AE6FCA478E3C79F036AD /* SEGAnalytics.m in Sources */,
-				7F99F346CEC7597BC4AD63F1E966D594 /* SEGAnalyticsRequest.m in Sources */,
-				B5F7A213B1C490590EFAB25DF6AFD48A /* SEGAnalyticsUtils.m in Sources */,
-				68E10C74572004B18490C31A0757E3B2 /* SEGBluetooth.m in Sources */,
-				66ED669D42B1035789CE51D6A5C86EB0 /* SEGGroupPayload.m in Sources */,
-				B09EF0FD07655A036EF25A09252EC9A9 /* SEGIdentifyPayload.m in Sources */,
-				B309BC0D714443A4A815F45FECB8AAB1 /* SEGLocation.m in Sources */,
-				EB27473B3153D1A32E331F8C3BC98E15 /* SEGPayload.m in Sources */,
-				A2A91F93C68DAE8C18FE53F6EA15D54D /* SEGReachability.m in Sources */,
-				10640AF349457B2280632CECCCA5FE7C /* SEGScreenPayload.m in Sources */,
-				3CF85CEBEA5339235C29E19B55D944ED /* SEGSegmentIntegration.m in Sources */,
-				8B1B60B7C24DCFAC0081FE5432C10942 /* SEGSegmentIntegrationFactory.m in Sources */,
-				02FA0FA148C2B4F13646BCD671C1DC0D /* SEGTrackPayload.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1132,7 +1156,7 @@
 		57FC9FF9A4FC85A51AF644E60D6E19D2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
+			target = 8056D060CDB25304FD112AB00556C3F3 /* Analytics */;
 			targetProxy = 50392894FCAF2CB4A9816C65D5D99379 /* PBXContainerItemProxy */;
 		};
 		6E6622F78168EF8FF0E13EEDEDE1290F /* PBXTargetDependency */ = {
@@ -1144,13 +1168,13 @@
 		A203D0DFBC0FB5CBF99F224515F6857B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
+			target = 8056D060CDB25304FD112AB00556C3F3 /* Analytics */;
 			targetProxy = B1D0C63210E1A60420D426381255CCC6 /* PBXContainerItemProxy */;
 		};
 		B020C18D2CFB83DABB6E414929EB63A0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
+			target = 8056D060CDB25304FD112AB00556C3F3 /* Analytics */;
 			targetProxy = 5C366DB458299DE65540310A35A238A8 /* PBXContainerItemProxy */;
 		};
 		B4A48C2E5DC19A046F8DBC790DBDEF7E /* PBXTargetDependency */ = {
@@ -1174,9 +1198,27 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		18D2D1F8D8D2C1AB3ACA586DE2F5C814 /* Release */ = {
+		0E11939A28652CBE2D3EDDB93D7C9CE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 107BB7AF015AC09039FCB83D812A0807 /* Analytics.xcconfig */;
+			baseConfigurationReference = 9C07E758DC9189F2CDEA5E8C022F01AE /* Analytics.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		10333FE8675B795A0294C623F2B945A6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9C07E758DC9189F2CDEA5E8C022F01AE /* Analytics.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
@@ -1212,7 +1254,7 @@
 		};
 		1BC29259D6F9F1A79B534F2B8B4D8363 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D27A51695046136C8B4448C98C9BAE7 /* Expecta.xcconfig */;
+			baseConfigurationReference = 32089C83AE0C7FDF6BFAC14CCA4FD8E3 /* Expecta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
@@ -1230,7 +1272,7 @@
 		};
 		644DD7F824C94CD2A5C88663CB57ED1A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A2A7DCEA109B03C296AE51E457E70F3 /* Specta.xcconfig */;
+			baseConfigurationReference = 88132AADBA174FF46EA3EE7B51E11F75 /* Specta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
@@ -1248,7 +1290,7 @@
 		};
 		6E073A0D16A8DFAEE80519C2A1D9553C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D27A51695046136C8B4448C98C9BAE7 /* Expecta.xcconfig */;
+			baseConfigurationReference = 32089C83AE0C7FDF6BFAC14CCA4FD8E3 /* Expecta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
@@ -1266,7 +1308,7 @@
 		};
 		769A822CAA7DE205888E9F9247E760C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A2A7DCEA109B03C296AE51E457E70F3 /* Specta.xcconfig */;
+			baseConfigurationReference = 88132AADBA174FF46EA3EE7B51E11F75 /* Specta.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
@@ -1407,24 +1449,6 @@
 			};
 			name = Debug;
 		};
-		E3D9551407884464577E58647CC2CDDE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 107BB7AF015AC09039FCB83D812A0807 /* Analytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
 		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1471,6 +1495,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		2AC10DFCC3C4BD299187A5E47F0035AE /* Build configuration list for PBXNativeTarget "Analytics" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0E11939A28652CBE2D3EDDB93D7C9CE5 /* Debug */,
+				10333FE8675B795A0294C623F2B945A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1512,15 +1545,6 @@
 			buildConfigurations = (
 				7970091F47C0B9E64BA08828F195D2A9 /* Debug */,
 				1A63BAB1EB19F1DD4040C05D17DDCD4A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D69A20A8681184C1F18D69A2BB644717 /* Build configuration list for PBXNativeTarget "Analytics" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E3D9551407884464577E58647CC2CDDE /* Debug */,
-				18D2D1F8D8D2C1AB3ACA586DE2F5C814 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-Optimizely.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-Optimizely.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'A2B146C1E9EE0386AE76BFC4'
+               BlueprintIdentifier = '67E402D0316CDC3CE02A5ADE'
                BlueprintName = 'Segment-Optimizely'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libSegment-Optimizely.a'>

--- a/Segment-Optimizely.podspec
+++ b/Segment-Optimizely.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3.0.3'
+  s.dependency 'Analytics', '~> 3.0'
   s.dependency 'Optimizely-iOS-SDK', '~> 1.4.2'
 end


### PR DESCRIPTION
I forgot to change this when I updated the deprecated method. Instead of pinning `3.0.3`, having `3.0` allows for all versions of `Analytics 3.0` - < `4.0`
