### PR TITLE
Relax Optimizely dependency

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - Optimizely-iOS-SDK (1.4.2)
   - Segment-Optimizely (1.1.1):
     - Analytics (~> 3.0)
-    - Optimizely-iOS-SDK (~> 1.4.2)
+    - Optimizely-iOS-SDK (~> 1.0)
   - Specta (1.0.5)
 
 DEPENDENCIES:
@@ -20,7 +20,7 @@ SPEC CHECKSUMS:
   Analytics: d801f32615853ca3108216423dbaa829c74f5927
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Optimizely-iOS-SDK: 6d23c5cde187f894430d134caa15f56874754cca
-  Segment-Optimizely: 41fff47c944306d1caf3be913cd2c9b6f762d602
+  Segment-Optimizely: 921546e959d4e4694cd6a5477ff24caf7025b461
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 PODFILE CHECKSUM: e8daa1f1943b45ec568a62840a539d474b5d8f19

--- a/Segment-Optimizely.podspec
+++ b/Segment-Optimizely.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Optimizely-iOS-SDK', '~> 1.4.2'
+  s.dependency 'Optimizely-iOS-SDK', '~> 1.0'
 end


### PR DESCRIPTION
Normally we don't like to make releases for minor version bumps, however, by relaxing this requirement we can allow users to pull in versions 1 up to but not including version 2 of the Optimizely SDK. 

This was requested by a customer, [here](https://segment.atlassian.net/browse/EPD-2740). The temporary work around was to include the Optmizely version they desired in their podfile, since Cocoapods states it will respect the most up to version date. 

And finally, the integration we depend on was [1.4.2](https://developers.optimizely.com/classic/ios/changelog/index.html#1-5-0) which is over a year old. 