### PR TITLE
Update release doc to use `--allow-warnings`

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,4 +6,4 @@ Releasing
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
  5. `git push && git push --tags`
- 6. `pod trunk push Segment-Optimizely.podspec --use-libraries`
+ 6. `pod trunk push Segment-Optimizely.podspec --use-libraries --allow-warnings`


### PR DESCRIPTION
The command fails otherwise, I figured we may want to postpone a more clean solution like `:inhibit_warnings` in another ticket.