### PR TITLE
Add end-of-support announcement for Analytics-iOS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# ⚠️ End-of-Support Announcement for Analytics-iOS Integrations ⚠️
+
+Following the End-of-Support (EoS) for the core **Analytics-iOS SDK** in **March 2026**, this legacy integration repository is also deprecated and will no longer receive updates. 
+
+Segment's future development efforts are concentrated on the new **Analytics-Swift** ecosystem. 
+
+* To migrate your core SDK, please see the [Analytics-iOS to Analytics-Swift migration guide](https://segment.com/docs/connections/sources/catalog/libraries/mobile/swift/migration/).
+* To find the modern Swift equivalent for this specific integration, check the [Analytics-Swift Destination Plugins list](https://github.com/segment-integrations?q=analytics-swift).
+
 # Analytics
 
 [![CircleCI](https://circleci.com/gh/segment-integrations/analytics-ios-integration-optimizely.svg?style=svg)](https://circleci.com/gh/segment-integrations/analytics-ios-integration-optimizely)


### PR DESCRIPTION
Announce the end-of-support for Analytics-iOS SDK and this plugin and provide migration resources.